### PR TITLE
test: parametrize GCS Bucket for integration tests

### DIFF
--- a/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
+++ b/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
@@ -123,7 +123,6 @@ public class ITSystemTest {
   public static void setUp() throws IOException {
 
     imageAnnotatorClient = ImageAnnotatorClient.create();
-    /* get GCS location */
 
     /* create product */
     productSearchClient = ProductSearchClient.create();

--- a/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
+++ b/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
@@ -93,9 +93,19 @@ public class ITSystemTest {
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   private static final String ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String RESOURCES = "src/test/resources/";
-  private static final String SAMPLE_BUCKET = "gs://cloud-samples-data/vision/";
-  private static final String SAMPLE_URI =
-      "https://storage-download.googleapis.com/cloud-samples-data/vision/";
+  private static final String GCS_BUCKET_ENV_VAR = "GOOGLE_CLOUD_TESTS_VISION_BUCKET";
+  private static final String SAMPLE_BUCKET;
+  private static final String SAMPLE_URI;
+  static {
+    String GCS_BUCKET;
+    if (System.getenv(GCS_BUCKET_ENV_VAR) != null) {
+      GCS_BUCKET = System.getenv(GCS_BUCKET_ENV_VAR);
+    } else {
+      GCS_BUCKET = "cloud-samples-data";
+    }
+    SAMPLE_BUCKET = String.format("gs://%s/vision/", GCS_BUCKET);
+    SAMPLE_URI = String.format("https://storage-download.googleapis.com/%s/vision/", GCS_BUCKET);
+  }
   private static final String COMPUTE_REGION = "us-west1";
   private static final String LOCATION_NAME =
       LocationName.of(PROJECT_ID, COMPUTE_REGION).toString();

--- a/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
+++ b/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
@@ -96,6 +96,7 @@ public class ITSystemTest {
   private static final String GCS_BUCKET_ENV_VAR = "GOOGLE_CLOUD_TESTS_VISION_BUCKET";
   private static final String SAMPLE_BUCKET;
   private static final String SAMPLE_URI;
+
   static {
     String GCS_BUCKET;
     if (System.getenv(GCS_BUCKET_ENV_VAR) != null) {
@@ -106,6 +107,7 @@ public class ITSystemTest {
     SAMPLE_BUCKET = String.format("gs://%s/vision/", GCS_BUCKET);
     SAMPLE_URI = String.format("https://storage-download.googleapis.com/%s/vision/", GCS_BUCKET);
   }
+
   private static final String COMPUTE_REGION = "us-west1";
   private static final String LOCATION_NAME =
       LocationName.of(PROJECT_ID, COMPUTE_REGION).toString();


### PR DESCRIPTION
Parametrizing the GCS bucket allows integration tests to pass in a secure environment protected by VPC Service Controls.

The name of the GCS bucket would be made available as an environment variable during test time. If not found, the test can assume that it will access the default cloud-samples-data GCS bucket.