### PR TITLE
fix: remove duplicate tests that are flaky due to ml model returning …

### DIFF
--- a/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
+++ b/google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
@@ -394,34 +394,6 @@ public class ITSystemTest {
   }
 
   @Test
-  public void detectWebDetectionsTest() throws IOException {
-    List<AnnotateImageResponse> responses =
-        getResponsesList("landmark.jpg", Type.WEB_DETECTION, false);
-    List<String> actual = new ArrayList<>();
-    for (AnnotateImageResponse res : responses) {
-      WebDetection annotation = res.getWebDetection();
-      for (WebDetection.WebEntity entity : annotation.getWebEntitiesList()) {
-        actual.add(entity.getDescription());
-      }
-    }
-    assertTrue(actual.contains("The Palace Of Fine Arts"));
-  }
-
-  @Test
-  public void detectWebDetectionsGcsTest() throws IOException {
-    List<AnnotateImageResponse> responses =
-        getResponsesList("landmark/pofa.jpg", Type.WEB_DETECTION, true);
-    List<String> actual = new ArrayList<>();
-    for (AnnotateImageResponse res : responses) {
-      WebDetection annotation = res.getWebDetection();
-      for (WebDetection.WebEntity entity : annotation.getWebEntitiesList()) {
-        actual.add(entity.getDescription());
-      }
-    }
-    assertTrue(actual.contains("The Palace Of Fine Arts"));
-  }
-
-  @Test
   public void detectWebEntitiesTest() throws IOException {
     List<AnnotateImageResponse> responses = getResponsesList("city.jpg", Type.WEB_DETECTION, false);
     List<String> actual = new ArrayList<>();


### PR DESCRIPTION
…different results

Fixes #https://github.com/googleapis/java-vision/issues/57 (it's a good idea to open an issue first for context and/or discussion)

Looking at the tests, these tests are already handled by:
`detectWebEntitiesTest`
`detectWebEntitiesGcsTest`

And likely the issue with the assert is the API is sending back different results occasionally due to possible model changes or confidence changes. 