### PR TITLE
chore: Migrate vision synth.py to bazel

### DIFF
--- a/grpc-google-cloud-vision-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-vision-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/vision/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageAnnotatorGrpc.java
+++ b/grpc-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ImageAnnotatorGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1/image_annotator.proto")
 public final class ImageAnnotatorGrpc {
 
@@ -41,30 +41,20 @@ public final class ImageAnnotatorGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1.ImageAnnotator";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
-      METHOD_BATCH_ANNOTATE_IMAGES = getBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1.BatchAnnotateImagesRequest.class,
+      responseType = com.google.cloud.vision.v1.BatchAnnotateImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod() {
-    return getBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
-      getBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
             com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
@@ -81,8 +71,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ImageAnnotator", "BatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "BatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -101,30 +90,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
-          com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
-      METHOD_BATCH_ANNOTATE_FILES = getBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
           com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
       getBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1.BatchAnnotateFilesRequest.class,
+      responseType = com.google.cloud.vision.v1.BatchAnnotateFilesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
           com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
       getBatchAnnotateFilesMethod() {
-    return getBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
-          com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
-      getBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
             com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
@@ -140,9 +119,7 @@ public final class ImageAnnotatorGrpc {
                           com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ImageAnnotator", "BatchAnnotateFiles"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -161,30 +138,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateFilesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_IMAGES = getAsyncBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateImagesMethod() {
-    return getAsyncBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
             com.google.longrunning.Operation>
@@ -203,8 +170,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ImageAnnotator", "AsyncBatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -222,30 +188,20 @@ public final class ImageAnnotatorGrpc {
     return getAsyncBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_FILES = getAsyncBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod() {
-    return getAsyncBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
             com.google.longrunning.Operation>
@@ -263,8 +219,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ImageAnnotator", "AsyncBatchAnnotateFiles"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -284,19 +239,43 @@ public final class ImageAnnotatorGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ImageAnnotatorStub newStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub>() {
+          @java.lang.Override
+          public ImageAnnotatorStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ImageAnnotatorBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub>() {
+          @java.lang.Override
+          public ImageAnnotatorBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorBlockingStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ImageAnnotatorFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub>() {
+          @java.lang.Override
+          public ImageAnnotatorFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorFutureStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -321,7 +300,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1.BatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -340,7 +319,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1.BatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateFilesMethod(), responseObserver);
     }
 
     /**
@@ -359,7 +338,7 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateImages(
         com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -377,35 +356,35 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getBatchAnnotateImagesMethodHelper(),
+              getBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.BatchAnnotateImagesRequest,
                       com.google.cloud.vision.v1.BatchAnnotateImagesResponse>(
                       this, METHODID_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getBatchAnnotateFilesMethodHelper(),
+              getBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.BatchAnnotateFilesRequest,
                       com.google.cloud.vision.v1.BatchAnnotateFilesResponse>(
                       this, METHODID_BATCH_ANNOTATE_FILES)))
           .addMethod(
-              getAsyncBatchAnnotateImagesMethodHelper(),
+              getAsyncBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_ASYNC_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getAsyncBatchAnnotateFilesMethodHelper(),
+              getAsyncBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest,
@@ -424,11 +403,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorStub> {
-    private ImageAnnotatorStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ImageAnnotatorStub> {
     private ImageAnnotatorStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -450,7 +425,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -472,7 +447,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -494,7 +469,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -515,7 +490,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -531,11 +506,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorBlockingStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorBlockingStub> {
-    private ImageAnnotatorBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ImageAnnotatorBlockingStub> {
     private ImageAnnotatorBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -556,7 +527,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1.BatchAnnotateImagesResponse batchAnnotateImages(
         com.google.cloud.vision.v1.BatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -574,7 +545,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1.BatchAnnotateFilesResponse batchAnnotateFiles(
         com.google.cloud.vision.v1.BatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -593,7 +564,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateImages(
         com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -611,7 +582,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
   }
 
@@ -625,11 +596,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorFutureStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorFutureStub> {
-    private ImageAnnotatorFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ImageAnnotatorFutureStub> {
     private ImageAnnotatorFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -651,7 +618,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1.BatchAnnotateImagesResponse>
         batchAnnotateImages(com.google.cloud.vision.v1.BatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -670,7 +637,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1.BatchAnnotateFilesResponse>
         batchAnnotateFiles(com.google.cloud.vision.v1.BatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateFilesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -690,8 +657,7 @@ public final class ImageAnnotatorGrpc {
         asyncBatchAnnotateImages(
             com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -709,8 +675,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         asyncBatchAnnotateFiles(com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
   }
 
@@ -822,10 +787,10 @@ public final class ImageAnnotatorGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ImageAnnotatorFileDescriptorSupplier())
-                      .addMethod(getBatchAnnotateImagesMethodHelper())
-                      .addMethod(getBatchAnnotateFilesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateImagesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateFilesMethodHelper())
+                      .addMethod(getBatchAnnotateImagesMethod())
+                      .addMethod(getBatchAnnotateFilesMethod())
+                      .addMethod(getAsyncBatchAnnotateImagesMethod())
+                      .addMethod(getAsyncBatchAnnotateFilesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ProductSearchGrpc.java
+++ b/grpc-google-cloud-vision-v1/src/main/java/com/google/cloud/vision/v1/ProductSearchGrpc.java
@@ -39,7 +39,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1/product_search_service.proto")
 public final class ProductSearchGrpc {
 
@@ -48,26 +48,18 @@ public final class ProductSearchGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1.ProductSearch";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      METHOD_CREATE_PRODUCT_SET = getCreateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getCreateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProductSet",
+      requestType = com.google.cloud.vision.v1.CreateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getCreateProductSetMethod() {
-    return getCreateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      getCreateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.CreateProductSetRequest,
             com.google.cloud.vision.v1.ProductSet>
@@ -82,9 +74,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "CreateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -102,30 +92,20 @@ public final class ProductSearchGrpc {
     return getCreateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductSetsRequest,
-          com.google.cloud.vision.v1.ListProductSetsResponse>
-      METHOD_LIST_PRODUCT_SETS = getListProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductSetsRequest,
           com.google.cloud.vision.v1.ListProductSetsResponse>
       getListProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductSets",
+      requestType = com.google.cloud.vision.v1.ListProductSetsRequest.class,
+      responseType = com.google.cloud.vision.v1.ListProductSetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductSetsRequest,
           com.google.cloud.vision.v1.ListProductSetsResponse>
       getListProductSetsMethod() {
-    return getListProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductSetsRequest,
-          com.google.cloud.vision.v1.ListProductSetsResponse>
-      getListProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.ListProductSetsRequest,
             com.google.cloud.vision.v1.ListProductSetsResponse>
@@ -140,9 +120,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ListProductSetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "ListProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -161,26 +139,18 @@ public final class ProductSearchGrpc {
     return getListProductSetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      METHOD_GET_PRODUCT_SET = getGetProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getGetProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProductSet",
+      requestType = com.google.cloud.vision.v1.GetProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getGetProductSetMethod() {
-    return getGetProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      getGetProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.GetProductSetRequest, com.google.cloud.vision.v1.ProductSet>
         getGetProductSetMethod;
@@ -194,9 +164,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "GetProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -213,26 +181,18 @@ public final class ProductSearchGrpc {
     return getGetProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.UpdateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      METHOD_UPDATE_PRODUCT_SET = getUpdateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.UpdateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getUpdateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProductSet",
+      requestType = com.google.cloud.vision.v1.UpdateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.UpdateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
       getUpdateProductSetMethod() {
-    return getUpdateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.UpdateProductSetRequest, com.google.cloud.vision.v1.ProductSet>
-      getUpdateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.UpdateProductSetRequest,
             com.google.cloud.vision.v1.ProductSet>
@@ -247,9 +207,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "UpdateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -267,26 +225,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT_SET = getDeleteProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProductSet",
+      requestType = com.google.cloud.vision.v1.DeleteProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod() {
-    return getDeleteProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      getDeleteProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.DeleteProductSetRequest, com.google.protobuf.Empty>
         getDeleteProductSetMethod;
@@ -300,9 +250,7 @@ public final class ProductSearchGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "DeleteProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -320,26 +268,18 @@ public final class ProductSearchGrpc {
     return getDeleteProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateProductRequest, com.google.cloud.vision.v1.Product>
-      METHOD_CREATE_PRODUCT = getCreateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateProductRequest, com.google.cloud.vision.v1.Product>
       getCreateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProduct",
+      requestType = com.google.cloud.vision.v1.CreateProductRequest.class,
+      responseType = com.google.cloud.vision.v1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateProductRequest, com.google.cloud.vision.v1.Product>
       getCreateProductMethod() {
-    return getCreateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateProductRequest, com.google.cloud.vision.v1.Product>
-      getCreateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.CreateProductRequest, com.google.cloud.vision.v1.Product>
         getCreateProductMethod;
@@ -353,9 +293,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "CreateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -372,30 +310,20 @@ public final class ProductSearchGrpc {
     return getCreateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductsRequest,
-          com.google.cloud.vision.v1.ListProductsResponse>
-      METHOD_LIST_PRODUCTS = getListProductsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductsRequest,
           com.google.cloud.vision.v1.ListProductsResponse>
       getListProductsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProducts",
+      requestType = com.google.cloud.vision.v1.ListProductsRequest.class,
+      responseType = com.google.cloud.vision.v1.ListProductsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductsRequest,
           com.google.cloud.vision.v1.ListProductsResponse>
       getListProductsMethod() {
-    return getListProductsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductsRequest,
-          com.google.cloud.vision.v1.ListProductsResponse>
-      getListProductsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.ListProductsRequest,
             com.google.cloud.vision.v1.ListProductsResponse>
@@ -410,9 +338,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ListProductsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "ListProducts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProducts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -429,26 +355,18 @@ public final class ProductSearchGrpc {
     return getListProductsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetProductRequest, com.google.cloud.vision.v1.Product>
-      METHOD_GET_PRODUCT = getGetProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetProductRequest, com.google.cloud.vision.v1.Product>
       getGetProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProduct",
+      requestType = com.google.cloud.vision.v1.GetProductRequest.class,
+      responseType = com.google.cloud.vision.v1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetProductRequest, com.google.cloud.vision.v1.Product>
       getGetProductMethod() {
-    return getGetProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetProductRequest, com.google.cloud.vision.v1.Product>
-      getGetProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.GetProductRequest, com.google.cloud.vision.v1.Product>
         getGetProductMethod;
@@ -462,9 +380,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "GetProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -480,26 +396,18 @@ public final class ProductSearchGrpc {
     return getGetProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.UpdateProductRequest, com.google.cloud.vision.v1.Product>
-      METHOD_UPDATE_PRODUCT = getUpdateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.UpdateProductRequest, com.google.cloud.vision.v1.Product>
       getUpdateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProduct",
+      requestType = com.google.cloud.vision.v1.UpdateProductRequest.class,
+      responseType = com.google.cloud.vision.v1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.UpdateProductRequest, com.google.cloud.vision.v1.Product>
       getUpdateProductMethod() {
-    return getUpdateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.UpdateProductRequest, com.google.cloud.vision.v1.Product>
-      getUpdateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.UpdateProductRequest, com.google.cloud.vision.v1.Product>
         getUpdateProductMethod;
@@ -513,9 +421,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "UpdateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -532,26 +438,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT = getDeleteProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProduct",
+      requestType = com.google.cloud.vision.v1.DeleteProductRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod() {
-    return getDeleteProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
-      getDeleteProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
         getDeleteProductMethod;
@@ -564,9 +462,7 @@ public final class ProductSearchGrpc {
                       .<com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "DeleteProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -583,30 +479,20 @@ public final class ProductSearchGrpc {
     return getDeleteProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1.ReferenceImage>
-      METHOD_CREATE_REFERENCE_IMAGE = getCreateReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1.ReferenceImage>
       getCreateReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateReferenceImage",
+      requestType = com.google.cloud.vision.v1.CreateReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1.ReferenceImage>
       getCreateReferenceImageMethod() {
-    return getCreateReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1.ReferenceImage>
-      getCreateReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.CreateReferenceImageRequest,
             com.google.cloud.vision.v1.ReferenceImage>
@@ -623,8 +509,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "CreateReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "CreateReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -642,26 +527,18 @@ public final class ProductSearchGrpc {
     return getCreateReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_REFERENCE_IMAGE = getDeleteReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteReferenceImage",
+      requestType = com.google.cloud.vision.v1.DeleteReferenceImageRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod() {
-    return getDeleteReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      getDeleteReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
         getDeleteReferenceImageMethod;
@@ -677,8 +554,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "DeleteReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -696,30 +572,20 @@ public final class ProductSearchGrpc {
     return getDeleteReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListReferenceImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1.ListReferenceImagesResponse>
-      METHOD_LIST_REFERENCE_IMAGES = getListReferenceImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1.ListReferenceImagesResponse>
       getListReferenceImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListReferenceImages",
+      requestType = com.google.cloud.vision.v1.ListReferenceImagesRequest.class,
+      responseType = com.google.cloud.vision.v1.ListReferenceImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1.ListReferenceImagesResponse>
       getListReferenceImagesMethod() {
-    return getListReferenceImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1.ListReferenceImagesResponse>
-      getListReferenceImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.ListReferenceImagesRequest,
             com.google.cloud.vision.v1.ListReferenceImagesResponse>
@@ -736,8 +602,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "ListReferenceImages"))
+                          generateFullMethodName(SERVICE_NAME, "ListReferenceImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -756,30 +621,20 @@ public final class ProductSearchGrpc {
     return getListReferenceImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1.ReferenceImage>
-      METHOD_GET_REFERENCE_IMAGE = getGetReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetReferenceImageRequest,
           com.google.cloud.vision.v1.ReferenceImage>
       getGetReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetReferenceImage",
+      requestType = com.google.cloud.vision.v1.GetReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.GetReferenceImageRequest,
           com.google.cloud.vision.v1.ReferenceImage>
       getGetReferenceImageMethod() {
-    return getGetReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1.ReferenceImage>
-      getGetReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.GetReferenceImageRequest,
             com.google.cloud.vision.v1.ReferenceImage>
@@ -794,9 +649,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1.ReferenceImage>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "GetReferenceImage"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -814,26 +667,18 @@ public final class ProductSearchGrpc {
     return getGetReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAddProductToProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AddProductToProductSetRequest, com.google.protobuf.Empty>
-      METHOD_ADD_PRODUCT_TO_PRODUCT_SET = getAddProductToProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AddProductToProductSetRequest, com.google.protobuf.Empty>
       getAddProductToProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AddProductToProductSet",
+      requestType = com.google.cloud.vision.v1.AddProductToProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.AddProductToProductSetRequest, com.google.protobuf.Empty>
       getAddProductToProductSetMethod() {
-    return getAddProductToProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.AddProductToProductSetRequest, com.google.protobuf.Empty>
-      getAddProductToProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.AddProductToProductSetRequest, com.google.protobuf.Empty>
         getAddProductToProductSetMethod;
@@ -850,8 +695,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "AddProductToProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "AddProductToProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -869,26 +713,18 @@ public final class ProductSearchGrpc {
     return getAddProductToProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRemoveProductFromProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.RemoveProductFromProductSetRequest, com.google.protobuf.Empty>
-      METHOD_REMOVE_PRODUCT_FROM_PRODUCT_SET = getRemoveProductFromProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.RemoveProductFromProductSetRequest, com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RemoveProductFromProductSet",
+      requestType = com.google.cloud.vision.v1.RemoveProductFromProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.RemoveProductFromProductSetRequest, com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod() {
-    return getRemoveProductFromProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.RemoveProductFromProductSetRequest, com.google.protobuf.Empty>
-      getRemoveProductFromProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.RemoveProductFromProductSetRequest,
             com.google.protobuf.Empty>
@@ -908,9 +744,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch",
-                              "RemoveProductFromProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "RemoveProductFromProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -928,30 +762,20 @@ public final class ProductSearchGrpc {
     return getRemoveProductFromProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsInProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1.ListProductsInProductSetResponse>
-      METHOD_LIST_PRODUCTS_IN_PRODUCT_SET = getListProductsInProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductsInProductSet",
+      requestType = com.google.cloud.vision.v1.ListProductsInProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1.ListProductsInProductSetResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod() {
-    return getListProductsInProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1.ListProductsInProductSetResponse>
-      getListProductsInProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.ListProductsInProductSetRequest,
             com.google.cloud.vision.v1.ListProductsInProductSetResponse>
@@ -970,8 +794,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "ListProductsInProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "ListProductsInProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -990,26 +813,18 @@ public final class ProductSearchGrpc {
     return getListProductsInProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ImportProductSetsRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_PRODUCT_SETS = getImportProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ImportProductSetsRequest, com.google.longrunning.Operation>
       getImportProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportProductSets",
+      requestType = com.google.cloud.vision.v1.ImportProductSetsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.ImportProductSetsRequest, com.google.longrunning.Operation>
       getImportProductSetsMethod() {
-    return getImportProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.ImportProductSetsRequest, com.google.longrunning.Operation>
-      getImportProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.ImportProductSetsRequest, com.google.longrunning.Operation>
         getImportProductSetsMethod;
@@ -1023,9 +838,7 @@ public final class ProductSearchGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "ImportProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1043,26 +856,18 @@ public final class ProductSearchGrpc {
     return getImportProductSetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getPurgeProductsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.PurgeProductsRequest, com.google.longrunning.Operation>
-      METHOD_PURGE_PRODUCTS = getPurgeProductsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.PurgeProductsRequest, com.google.longrunning.Operation>
       getPurgeProductsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "PurgeProducts",
+      requestType = com.google.cloud.vision.v1.PurgeProductsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1.PurgeProductsRequest, com.google.longrunning.Operation>
       getPurgeProductsMethod() {
-    return getPurgeProductsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1.PurgeProductsRequest, com.google.longrunning.Operation>
-      getPurgeProductsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1.PurgeProductsRequest, com.google.longrunning.Operation>
         getPurgeProductsMethod;
@@ -1076,9 +881,7 @@ public final class ProductSearchGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1.ProductSearch", "PurgeProducts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "PurgeProducts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1097,19 +900,43 @@ public final class ProductSearchGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ProductSearchStub newStub(io.grpc.Channel channel) {
-    return new ProductSearchStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub>() {
+          @java.lang.Override
+          public ProductSearchStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchStub(channel, callOptions);
+          }
+        };
+    return ProductSearchStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ProductSearchBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ProductSearchBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub>() {
+          @java.lang.Override
+          public ProductSearchBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchBlockingStub(channel, callOptions);
+          }
+        };
+    return ProductSearchBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ProductSearchFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ProductSearchFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub>() {
+          @java.lang.Override
+          public ProductSearchFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchFutureStub(channel, callOptions);
+          }
+        };
+    return ProductSearchFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1143,7 +970,7 @@ public final class ProductSearchGrpc {
     public void createProductSet(
         com.google.cloud.vision.v1.CreateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1160,7 +987,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.ListProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductSetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductSetsMethod(), responseObserver);
     }
 
     /**
@@ -1175,7 +1002,7 @@ public final class ProductSearchGrpc {
     public void getProductSet(
         com.google.cloud.vision.v1.GetProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1193,7 +1020,7 @@ public final class ProductSearchGrpc {
     public void updateProductSet(
         com.google.cloud.vision.v1.UpdateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1208,7 +1035,7 @@ public final class ProductSearchGrpc {
     public void deleteProductSet(
         com.google.cloud.vision.v1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1226,7 +1053,7 @@ public final class ProductSearchGrpc {
     public void createProduct(
         com.google.cloud.vision.v1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductMethod(), responseObserver);
     }
 
     /**
@@ -1242,7 +1069,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.ListProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsMethod(), responseObserver);
     }
 
     /**
@@ -1257,7 +1084,7 @@ public final class ProductSearchGrpc {
     public void getProduct(
         com.google.cloud.vision.v1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductMethod(), responseObserver);
     }
 
     /**
@@ -1281,7 +1108,7 @@ public final class ProductSearchGrpc {
     public void updateProduct(
         com.google.cloud.vision.v1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductMethod(), responseObserver);
     }
 
     /**
@@ -1297,7 +1124,7 @@ public final class ProductSearchGrpc {
     public void deleteProduct(
         com.google.cloud.vision.v1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductMethod(), responseObserver);
     }
 
     /**
@@ -1324,7 +1151,7 @@ public final class ProductSearchGrpc {
     public void createReferenceImage(
         com.google.cloud.vision.v1.CreateReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ReferenceImage> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1341,7 +1168,7 @@ public final class ProductSearchGrpc {
     public void deleteReferenceImage(
         com.google.cloud.vision.v1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1359,7 +1186,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.ListReferenceImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListReferenceImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListReferenceImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListReferenceImagesMethod(), responseObserver);
     }
 
     /**
@@ -1374,7 +1201,7 @@ public final class ProductSearchGrpc {
     public void getReferenceImage(
         com.google.cloud.vision.v1.GetReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ReferenceImage> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1391,7 +1218,7 @@ public final class ProductSearchGrpc {
     public void addProductToProductSet(
         com.google.cloud.vision.v1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getAddProductToProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAddProductToProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1404,7 +1231,7 @@ public final class ProductSearchGrpc {
     public void removeProductFromProductSet(
         com.google.cloud.vision.v1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1422,7 +1249,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.ListProductsInProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductsInProductSetResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsInProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsInProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1443,7 +1270,7 @@ public final class ProductSearchGrpc {
     public void importProductSets(
         com.google.cloud.vision.v1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportProductSetsMethod(), responseObserver);
     }
 
     /**
@@ -1474,128 +1301,128 @@ public final class ProductSearchGrpc {
     public void purgeProducts(
         com.google.cloud.vision.v1.PurgeProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getPurgeProductsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getPurgeProductsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateProductSetMethodHelper(),
+              getCreateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.CreateProductSetRequest,
                       com.google.cloud.vision.v1.ProductSet>(this, METHODID_CREATE_PRODUCT_SET)))
           .addMethod(
-              getListProductSetsMethodHelper(),
+              getListProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.ListProductSetsRequest,
                       com.google.cloud.vision.v1.ListProductSetsResponse>(
                       this, METHODID_LIST_PRODUCT_SETS)))
           .addMethod(
-              getGetProductSetMethodHelper(),
+              getGetProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.GetProductSetRequest,
                       com.google.cloud.vision.v1.ProductSet>(this, METHODID_GET_PRODUCT_SET)))
           .addMethod(
-              getUpdateProductSetMethodHelper(),
+              getUpdateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.UpdateProductSetRequest,
                       com.google.cloud.vision.v1.ProductSet>(this, METHODID_UPDATE_PRODUCT_SET)))
           .addMethod(
-              getDeleteProductSetMethodHelper(),
+              getDeleteProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.DeleteProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_PRODUCT_SET)))
           .addMethod(
-              getCreateProductMethodHelper(),
+              getCreateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.CreateProductRequest,
                       com.google.cloud.vision.v1.Product>(this, METHODID_CREATE_PRODUCT)))
           .addMethod(
-              getListProductsMethodHelper(),
+              getListProductsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.ListProductsRequest,
                       com.google.cloud.vision.v1.ListProductsResponse>(
                       this, METHODID_LIST_PRODUCTS)))
           .addMethod(
-              getGetProductMethodHelper(),
+              getGetProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.GetProductRequest,
                       com.google.cloud.vision.v1.Product>(this, METHODID_GET_PRODUCT)))
           .addMethod(
-              getUpdateProductMethodHelper(),
+              getUpdateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.UpdateProductRequest,
                       com.google.cloud.vision.v1.Product>(this, METHODID_UPDATE_PRODUCT)))
           .addMethod(
-              getDeleteProductMethodHelper(),
+              getDeleteProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.DeleteProductRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_PRODUCT)))
           .addMethod(
-              getCreateReferenceImageMethodHelper(),
+              getCreateReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.CreateReferenceImageRequest,
                       com.google.cloud.vision.v1.ReferenceImage>(
                       this, METHODID_CREATE_REFERENCE_IMAGE)))
           .addMethod(
-              getDeleteReferenceImageMethodHelper(),
+              getDeleteReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.DeleteReferenceImageRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_REFERENCE_IMAGE)))
           .addMethod(
-              getListReferenceImagesMethodHelper(),
+              getListReferenceImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.ListReferenceImagesRequest,
                       com.google.cloud.vision.v1.ListReferenceImagesResponse>(
                       this, METHODID_LIST_REFERENCE_IMAGES)))
           .addMethod(
-              getGetReferenceImageMethodHelper(),
+              getGetReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.GetReferenceImageRequest,
                       com.google.cloud.vision.v1.ReferenceImage>(
                       this, METHODID_GET_REFERENCE_IMAGE)))
           .addMethod(
-              getAddProductToProductSetMethodHelper(),
+              getAddProductToProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.AddProductToProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_ADD_PRODUCT_TO_PRODUCT_SET)))
           .addMethod(
-              getRemoveProductFromProductSetMethodHelper(),
+              getRemoveProductFromProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.RemoveProductFromProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_REMOVE_PRODUCT_FROM_PRODUCT_SET)))
           .addMethod(
-              getListProductsInProductSetMethodHelper(),
+              getListProductsInProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.ListProductsInProductSetRequest,
                       com.google.cloud.vision.v1.ListProductsInProductSetResponse>(
                       this, METHODID_LIST_PRODUCTS_IN_PRODUCT_SET)))
           .addMethod(
-              getImportProductSetsMethodHelper(),
+              getImportProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.ImportProductSetsRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_PRODUCT_SETS)))
           .addMethod(
-              getPurgeProductsMethodHelper(),
+              getPurgeProductsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1.PurgeProductsRequest,
@@ -1620,11 +1447,8 @@ public final class ProductSearchGrpc {
    *   `projects/&#42;&#47;locations/&#42;&#47;products/&#42;&#47;referenceImages/&#42;`
    * </pre>
    */
-  public static final class ProductSearchStub extends io.grpc.stub.AbstractStub<ProductSearchStub> {
-    private ProductSearchStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class ProductSearchStub
+      extends io.grpc.stub.AbstractAsyncStub<ProductSearchStub> {
     private ProductSearchStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1648,7 +1472,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.CreateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1668,7 +1492,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductSetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1686,7 +1510,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.GetProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1707,7 +1531,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.UpdateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ProductSet> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1725,7 +1549,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1746,7 +1570,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1765,7 +1589,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1783,9 +1607,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1810,7 +1632,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1829,7 +1651,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1859,7 +1681,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.CreateReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ReferenceImage> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1879,7 +1701,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1900,7 +1722,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListReferenceImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1918,7 +1740,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.GetReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ReferenceImage> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1938,7 +1760,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1954,7 +1776,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1975,7 +1797,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1.ListProductsInProductSetResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1999,7 +1821,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2033,7 +1855,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1.PurgeProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getPurgeProductsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getPurgeProductsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2056,11 +1878,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchBlockingStub
-      extends io.grpc.stub.AbstractStub<ProductSearchBlockingStub> {
-    private ProductSearchBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ProductSearchBlockingStub> {
     private ProductSearchBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2084,7 +1902,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ProductSet createProductSet(
         com.google.cloud.vision.v1.CreateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2099,8 +1917,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.ListProductSetsResponse listProductSets(
         com.google.cloud.vision.v1.ListProductSetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductSetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductSetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2114,8 +1931,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.ProductSet getProductSet(
         com.google.cloud.vision.v1.GetProductSetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductSetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2133,7 +1949,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ProductSet updateProductSet(
         com.google.cloud.vision.v1.UpdateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2148,7 +1964,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteProductSet(
         com.google.cloud.vision.v1.DeleteProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2165,8 +1981,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.Product createProduct(
         com.google.cloud.vision.v1.CreateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2180,8 +1995,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.ListProductsResponse listProducts(
         com.google.cloud.vision.v1.ListProductsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2195,8 +2009,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.Product getProduct(
         com.google.cloud.vision.v1.GetProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2219,8 +2032,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1.Product updateProduct(
         com.google.cloud.vision.v1.UpdateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2235,8 +2047,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.protobuf.Empty deleteProduct(
         com.google.cloud.vision.v1.DeleteProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2263,7 +2074,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ReferenceImage createReferenceImage(
         com.google.cloud.vision.v1.CreateReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2280,7 +2091,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteReferenceImage(
         com.google.cloud.vision.v1.DeleteReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2297,7 +2108,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ListReferenceImagesResponse listReferenceImages(
         com.google.cloud.vision.v1.ListReferenceImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListReferenceImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListReferenceImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2312,7 +2123,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ReferenceImage getReferenceImage(
         com.google.cloud.vision.v1.GetReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2329,7 +2140,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty addProductToProductSet(
         com.google.cloud.vision.v1.AddProductToProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAddProductToProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getAddProductToProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2342,7 +2153,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty removeProductFromProductSet(
         com.google.cloud.vision.v1.RemoveProductFromProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRemoveProductFromProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getRemoveProductFromProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2359,7 +2170,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1.ListProductsInProductSetResponse listProductsInProductSet(
         com.google.cloud.vision.v1.ListProductsInProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListProductsInProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getListProductsInProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2380,7 +2191,7 @@ public final class ProductSearchGrpc {
     public com.google.longrunning.Operation importProductSets(
         com.google.cloud.vision.v1.ImportProductSetsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getImportProductSetsMethodHelper(), getCallOptions(), request);
+          getChannel(), getImportProductSetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2410,8 +2221,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.longrunning.Operation purgeProducts(
         com.google.cloud.vision.v1.PurgeProductsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getPurgeProductsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getPurgeProductsMethod(), getCallOptions(), request);
     }
   }
 
@@ -2432,11 +2242,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchFutureStub
-      extends io.grpc.stub.AbstractStub<ProductSearchFutureStub> {
-    private ProductSearchFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ProductSearchFutureStub> {
     private ProductSearchFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2460,7 +2266,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.ProductSet>
         createProductSet(com.google.cloud.vision.v1.CreateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2477,7 +2283,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1.ListProductSetsResponse>
         listProductSets(com.google.cloud.vision.v1.ListProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2492,7 +2298,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.ProductSet>
         getProductSet(com.google.cloud.vision.v1.GetProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2510,7 +2316,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.ProductSet>
         updateProductSet(com.google.cloud.vision.v1.UpdateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2525,7 +2331,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProductSet(com.google.cloud.vision.v1.DeleteProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2543,7 +2349,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.Product>
         createProduct(com.google.cloud.vision.v1.CreateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2559,7 +2365,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1.ListProductsResponse>
         listProducts(com.google.cloud.vision.v1.ListProductsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2574,7 +2380,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.Product>
         getProduct(com.google.cloud.vision.v1.GetProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2598,7 +2404,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.vision.v1.Product>
         updateProduct(com.google.cloud.vision.v1.UpdateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2614,7 +2420,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProduct(com.google.cloud.vision.v1.DeleteProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2642,7 +2448,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1.ReferenceImage>
         createReferenceImage(com.google.cloud.vision.v1.CreateReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2659,7 +2465,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteReferenceImage(com.google.cloud.vision.v1.DeleteReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2677,7 +2483,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1.ListReferenceImagesResponse>
         listReferenceImages(com.google.cloud.vision.v1.ListReferenceImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2693,7 +2499,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1.ReferenceImage>
         getReferenceImage(com.google.cloud.vision.v1.GetReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2710,7 +2516,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         addProductToProductSet(com.google.cloud.vision.v1.AddProductToProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2724,8 +2530,7 @@ public final class ProductSearchGrpc {
         removeProductFromProductSet(
             com.google.cloud.vision.v1.RemoveProductFromProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2744,8 +2549,7 @@ public final class ProductSearchGrpc {
         listProductsInProductSet(
             com.google.cloud.vision.v1.ListProductsInProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2766,7 +2570,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importProductSets(com.google.cloud.vision.v1.ImportProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2797,7 +2601,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         purgeProducts(com.google.cloud.vision.v1.PurgeProductsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getPurgeProductsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getPurgeProductsMethod(), getCallOptions()), request);
     }
   }
 
@@ -3007,25 +2811,25 @@ public final class ProductSearchGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ProductSearchFileDescriptorSupplier())
-                      .addMethod(getCreateProductSetMethodHelper())
-                      .addMethod(getListProductSetsMethodHelper())
-                      .addMethod(getGetProductSetMethodHelper())
-                      .addMethod(getUpdateProductSetMethodHelper())
-                      .addMethod(getDeleteProductSetMethodHelper())
-                      .addMethod(getCreateProductMethodHelper())
-                      .addMethod(getListProductsMethodHelper())
-                      .addMethod(getGetProductMethodHelper())
-                      .addMethod(getUpdateProductMethodHelper())
-                      .addMethod(getDeleteProductMethodHelper())
-                      .addMethod(getCreateReferenceImageMethodHelper())
-                      .addMethod(getDeleteReferenceImageMethodHelper())
-                      .addMethod(getListReferenceImagesMethodHelper())
-                      .addMethod(getGetReferenceImageMethodHelper())
-                      .addMethod(getAddProductToProductSetMethodHelper())
-                      .addMethod(getRemoveProductFromProductSetMethodHelper())
-                      .addMethod(getListProductsInProductSetMethodHelper())
-                      .addMethod(getImportProductSetsMethodHelper())
-                      .addMethod(getPurgeProductsMethodHelper())
+                      .addMethod(getCreateProductSetMethod())
+                      .addMethod(getListProductSetsMethod())
+                      .addMethod(getGetProductSetMethod())
+                      .addMethod(getUpdateProductSetMethod())
+                      .addMethod(getDeleteProductSetMethod())
+                      .addMethod(getCreateProductMethod())
+                      .addMethod(getListProductsMethod())
+                      .addMethod(getGetProductMethod())
+                      .addMethod(getUpdateProductMethod())
+                      .addMethod(getDeleteProductMethod())
+                      .addMethod(getCreateReferenceImageMethod())
+                      .addMethod(getDeleteReferenceImageMethod())
+                      .addMethod(getListReferenceImagesMethod())
+                      .addMethod(getGetReferenceImageMethod())
+                      .addMethod(getAddProductToProductSetMethod())
+                      .addMethod(getRemoveProductFromProductSetMethod())
+                      .addMethod(getListProductsInProductSetMethod())
+                      .addMethod(getImportProductSetsMethod())
+                      .addMethod(getPurgeProductsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-vision-v1p1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/vision/v1p1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-vision-v1p1beta1/src/main/java/com/google/cloud/vision/v1p1beta1/ImageAnnotatorGrpc.java
+++ b/grpc-google-cloud-vision-v1p1beta1/src/main/java/com/google/cloud/vision/v1p1beta1/ImageAnnotatorGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p1beta1/image_annotator.proto")
 public final class ImageAnnotatorGrpc {
 
@@ -41,30 +41,20 @@ public final class ImageAnnotatorGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p1beta1.ImageAnnotator";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
-      METHOD_BATCH_ANNOTATE_IMAGES = getBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod() {
-    return getBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
-      getBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
             com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
@@ -81,9 +71,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p1beta1.ImageAnnotator",
-                              "BatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "BatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -104,19 +92,43 @@ public final class ImageAnnotatorGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ImageAnnotatorStub newStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub>() {
+          @java.lang.Override
+          public ImageAnnotatorStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ImageAnnotatorBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub>() {
+          @java.lang.Override
+          public ImageAnnotatorBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorBlockingStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ImageAnnotatorFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub>() {
+          @java.lang.Override
+          public ImageAnnotatorFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorFutureStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -141,14 +153,14 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getBatchAnnotateImagesMethodHelper(),
+              getBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest,
@@ -168,11 +180,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorStub> {
-    private ImageAnnotatorStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ImageAnnotatorStub> {
     private ImageAnnotatorStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -194,7 +202,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -210,11 +218,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorBlockingStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorBlockingStub> {
-    private ImageAnnotatorBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ImageAnnotatorBlockingStub> {
     private ImageAnnotatorBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -235,7 +239,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse batchAnnotateImages(
         com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
   }
 
@@ -249,11 +253,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorFutureStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorFutureStub> {
-    private ImageAnnotatorFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ImageAnnotatorFutureStub> {
     private ImageAnnotatorFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -275,7 +275,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesResponse>
         batchAnnotateImages(com.google.cloud.vision.v1p1beta1.BatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
   }
 
@@ -369,7 +369,7 @@ public final class ImageAnnotatorGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ImageAnnotatorFileDescriptorSupplier())
-                      .addMethod(getBatchAnnotateImagesMethodHelper())
+                      .addMethod(getBatchAnnotateImagesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p2beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-vision-v1p2beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/vision/v1p2beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-vision-v1p2beta1/src/main/java/com/google/cloud/vision/v1p2beta1/ImageAnnotatorGrpc.java
+++ b/grpc-google-cloud-vision-v1p2beta1/src/main/java/com/google/cloud/vision/v1p2beta1/ImageAnnotatorGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p2beta1/image_annotator.proto")
 public final class ImageAnnotatorGrpc {
 
@@ -41,30 +41,20 @@ public final class ImageAnnotatorGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p2beta1.ImageAnnotator";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
-      METHOD_BATCH_ANNOTATE_IMAGES = getBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod() {
-    return getBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
-      getBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
             com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
@@ -81,9 +71,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p2beta1.ImageAnnotator",
-                              "BatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "BatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -102,30 +90,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_FILES = getAsyncBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod() {
-    return getAsyncBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
             com.google.longrunning.Operation>
@@ -143,9 +121,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p2beta1.ImageAnnotator",
-                              "AsyncBatchAnnotateFiles"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,19 +141,43 @@ public final class ImageAnnotatorGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ImageAnnotatorStub newStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub>() {
+          @java.lang.Override
+          public ImageAnnotatorStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ImageAnnotatorBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub>() {
+          @java.lang.Override
+          public ImageAnnotatorBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorBlockingStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ImageAnnotatorFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub>() {
+          @java.lang.Override
+          public ImageAnnotatorFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorFutureStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -202,7 +202,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -220,21 +220,21 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getBatchAnnotateImagesMethodHelper(),
+              getBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest,
                       com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>(
                       this, METHODID_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getAsyncBatchAnnotateFilesMethodHelper(),
+              getAsyncBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest,
@@ -253,11 +253,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorStub> {
-    private ImageAnnotatorStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ImageAnnotatorStub> {
     private ImageAnnotatorStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -279,7 +275,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -300,7 +296,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -316,11 +312,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorBlockingStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorBlockingStub> {
-    private ImageAnnotatorBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ImageAnnotatorBlockingStub> {
     private ImageAnnotatorBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -341,7 +333,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse batchAnnotateImages(
         com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -359,7 +351,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
   }
 
@@ -373,11 +365,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorFutureStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorFutureStub> {
-    private ImageAnnotatorFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ImageAnnotatorFutureStub> {
     private ImageAnnotatorFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -399,7 +387,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesResponse>
         batchAnnotateImages(com.google.cloud.vision.v1p2beta1.BatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -418,8 +406,7 @@ public final class ImageAnnotatorGrpc {
         asyncBatchAnnotateFiles(
             com.google.cloud.vision.v1p2beta1.AsyncBatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
   }
 
@@ -519,8 +506,8 @@ public final class ImageAnnotatorGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ImageAnnotatorFileDescriptorSupplier())
-                      .addMethod(getBatchAnnotateImagesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateFilesMethodHelper())
+                      .addMethod(getBatchAnnotateImagesMethod())
+                      .addMethod(getAsyncBatchAnnotateFilesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p3beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-vision-v1p3beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/vision/v1p3beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-vision-v1p3beta1/src/main/java/com/google/cloud/vision/v1p3beta1/ImageAnnotatorGrpc.java
+++ b/grpc-google-cloud-vision-v1p3beta1/src/main/java/com/google/cloud/vision/v1p3beta1/ImageAnnotatorGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p3beta1/image_annotator.proto")
 public final class ImageAnnotatorGrpc {
 
@@ -41,30 +41,20 @@ public final class ImageAnnotatorGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p3beta1.ImageAnnotator";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
-      METHOD_BATCH_ANNOTATE_IMAGES = getBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod() {
-    return getBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
-      getBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
             com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
@@ -81,9 +71,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ImageAnnotator",
-                              "BatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "BatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -102,30 +90,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_FILES = getAsyncBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod() {
-    return getAsyncBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
             com.google.longrunning.Operation>
@@ -143,9 +121,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ImageAnnotator",
-                              "AsyncBatchAnnotateFiles"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,19 +141,43 @@ public final class ImageAnnotatorGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ImageAnnotatorStub newStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub>() {
+          @java.lang.Override
+          public ImageAnnotatorStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ImageAnnotatorBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub>() {
+          @java.lang.Override
+          public ImageAnnotatorBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorBlockingStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ImageAnnotatorFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub>() {
+          @java.lang.Override
+          public ImageAnnotatorFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorFutureStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -202,7 +202,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -220,21 +220,21 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getBatchAnnotateImagesMethodHelper(),
+              getBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest,
                       com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>(
                       this, METHODID_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getAsyncBatchAnnotateFilesMethodHelper(),
+              getAsyncBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest,
@@ -253,11 +253,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorStub> {
-    private ImageAnnotatorStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ImageAnnotatorStub> {
     private ImageAnnotatorStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -279,7 +275,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -300,7 +296,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -316,11 +312,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorBlockingStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorBlockingStub> {
-    private ImageAnnotatorBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ImageAnnotatorBlockingStub> {
     private ImageAnnotatorBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -341,7 +333,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse batchAnnotateImages(
         com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -359,7 +351,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
   }
 
@@ -373,11 +365,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorFutureStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorFutureStub> {
-    private ImageAnnotatorFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ImageAnnotatorFutureStub> {
     private ImageAnnotatorFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -399,7 +387,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesResponse>
         batchAnnotateImages(com.google.cloud.vision.v1p3beta1.BatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -418,8 +406,7 @@ public final class ImageAnnotatorGrpc {
         asyncBatchAnnotateFiles(
             com.google.cloud.vision.v1p3beta1.AsyncBatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
   }
 
@@ -519,8 +506,8 @@ public final class ImageAnnotatorGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ImageAnnotatorFileDescriptorSupplier())
-                      .addMethod(getBatchAnnotateImagesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateFilesMethodHelper())
+                      .addMethod(getBatchAnnotateImagesMethod())
+                      .addMethod(getAsyncBatchAnnotateFilesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p3beta1/src/main/java/com/google/cloud/vision/v1p3beta1/ProductSearchGrpc.java
+++ b/grpc-google-cloud-vision-v1p3beta1/src/main/java/com/google/cloud/vision/v1p3beta1/ProductSearchGrpc.java
@@ -39,7 +39,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p3beta1/product_search_service.proto")
 public final class ProductSearchGrpc {
 
@@ -48,30 +48,20 @@ public final class ProductSearchGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p3beta1.ProductSearch";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      METHOD_CREATE_PRODUCT_SET = getCreateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getCreateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.CreateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getCreateProductSetMethod() {
-    return getCreateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      getCreateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
             com.google.cloud.vision.v1p3beta1.ProductSet>
@@ -86,9 +76,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "CreateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -106,30 +94,20 @@ public final class ProductSearchGrpc {
     return getCreateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
-      METHOD_LIST_PRODUCT_SETS = getListProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
           com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
       getListProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductSets",
+      requestType = com.google.cloud.vision.v1p3beta1.ListProductSetsRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ListProductSetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
           com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
       getListProductSetsMethod() {
-    return getListProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
-      getListProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
             com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
@@ -144,9 +122,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "ListProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,30 +141,20 @@ public final class ProductSearchGrpc {
     return getListProductSetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      METHOD_GET_PRODUCT_SET = getGetProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getGetProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.GetProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getGetProductSetMethod() {
-    return getGetProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      getGetProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
             com.google.cloud.vision.v1p3beta1.ProductSet>
@@ -203,9 +169,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "GetProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -223,30 +187,20 @@ public final class ProductSearchGrpc {
     return getGetProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      METHOD_UPDATE_PRODUCT_SET = getUpdateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getUpdateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ProductSet>
       getUpdateProductSetMethod() {
-    return getUpdateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ProductSet>
-      getUpdateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
             com.google.cloud.vision.v1p3beta1.ProductSet>
@@ -261,9 +215,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "UpdateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -281,26 +233,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT_SET = getDeleteProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod() {
-    return getDeleteProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      getDeleteProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
         getDeleteProductSetMethod;
@@ -314,9 +258,7 @@ public final class ProductSearchGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "DeleteProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -334,30 +276,20 @@ public final class ProductSearchGrpc {
     return getDeleteProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      METHOD_CREATE_PRODUCT = getCreateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getCreateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProduct",
+      requestType = com.google.cloud.vision.v1p3beta1.CreateProductRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getCreateProductMethod() {
-    return getCreateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      getCreateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.CreateProductRequest,
             com.google.cloud.vision.v1p3beta1.Product>
@@ -372,9 +304,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "CreateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -392,30 +322,20 @@ public final class ProductSearchGrpc {
     return getCreateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductsRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductsResponse>
-      METHOD_LIST_PRODUCTS = getListProductsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductsRequest,
           com.google.cloud.vision.v1p3beta1.ListProductsResponse>
       getListProductsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProducts",
+      requestType = com.google.cloud.vision.v1p3beta1.ListProductsRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ListProductsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductsRequest,
           com.google.cloud.vision.v1p3beta1.ListProductsResponse>
       getListProductsMethod() {
-    return getListProductsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductsRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductsResponse>
-      getListProductsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.ListProductsRequest,
             com.google.cloud.vision.v1p3beta1.ListProductsResponse>
@@ -430,9 +350,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ListProductsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "ListProducts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProducts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -451,30 +369,20 @@ public final class ProductSearchGrpc {
     return getListProductsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      METHOD_GET_PRODUCT = getGetProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getGetProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProduct",
+      requestType = com.google.cloud.vision.v1p3beta1.GetProductRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getGetProductMethod() {
-    return getGetProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      getGetProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.GetProductRequest,
             com.google.cloud.vision.v1p3beta1.Product>
@@ -489,9 +397,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "GetProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -508,30 +414,20 @@ public final class ProductSearchGrpc {
     return getGetProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      METHOD_UPDATE_PRODUCT = getUpdateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getUpdateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProduct",
+      requestType = com.google.cloud.vision.v1p3beta1.UpdateProductRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
           com.google.cloud.vision.v1p3beta1.Product>
       getUpdateProductMethod() {
-    return getUpdateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
-          com.google.cloud.vision.v1p3beta1.Product>
-      getUpdateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
             com.google.cloud.vision.v1p3beta1.Product>
@@ -546,9 +442,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "UpdateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -566,26 +460,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteProductRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT = getDeleteProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProduct",
+      requestType = com.google.cloud.vision.v1p3beta1.DeleteProductRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod() {
-    return getDeleteProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteProductRequest, com.google.protobuf.Empty>
-      getDeleteProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.DeleteProductRequest, com.google.protobuf.Empty>
         getDeleteProductMethod;
@@ -599,9 +485,7 @@ public final class ProductSearchGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "DeleteProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -619,30 +503,20 @@ public final class ProductSearchGrpc {
     return getDeleteProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1p3beta1.ReferenceImage>
-      METHOD_CREATE_REFERENCE_IMAGE = getCreateReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1p3beta1.ReferenceImage>
       getCreateReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateReferenceImage",
+      requestType = com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1p3beta1.ReferenceImage>
       getCreateReferenceImageMethod() {
-    return getCreateReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1p3beta1.ReferenceImage>
-      getCreateReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
             com.google.cloud.vision.v1p3beta1.ReferenceImage>
@@ -659,9 +533,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch",
-                              "CreateReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "CreateReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -680,26 +552,18 @@ public final class ProductSearchGrpc {
     return getCreateReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_REFERENCE_IMAGE = getDeleteReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteReferenceImage",
+      requestType = com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod() {
-    return getDeleteReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      getDeleteReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest,
             com.google.protobuf.Empty>
@@ -716,9 +580,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch",
-                              "DeleteReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -736,30 +598,20 @@ public final class ProductSearchGrpc {
     return getDeleteReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListReferenceImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
-      METHOD_LIST_REFERENCE_IMAGES = getListReferenceImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
       getListReferenceImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListReferenceImages",
+      requestType = com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
       getListReferenceImagesMethod() {
-    return getListReferenceImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
-      getListReferenceImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
             com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
@@ -776,8 +628,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "ListReferenceImages"))
+                          generateFullMethodName(SERVICE_NAME, "ListReferenceImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -796,30 +647,20 @@ public final class ProductSearchGrpc {
     return getListReferenceImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1p3beta1.ReferenceImage>
-      METHOD_GET_REFERENCE_IMAGE = getGetReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
           com.google.cloud.vision.v1p3beta1.ReferenceImage>
       getGetReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetReferenceImage",
+      requestType = com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
           com.google.cloud.vision.v1p3beta1.ReferenceImage>
       getGetReferenceImageMethod() {
-    return getGetReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1p3beta1.ReferenceImage>
-      getGetReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
             com.google.cloud.vision.v1p3beta1.ReferenceImage>
@@ -834,9 +675,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p3beta1.ReferenceImage>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "GetReferenceImage"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -855,30 +694,20 @@ public final class ProductSearchGrpc {
     return getGetReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAddProductToProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
-          com.google.protobuf.Empty>
-      METHOD_ADD_PRODUCT_TO_PRODUCT_SET = getAddProductToProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
           com.google.protobuf.Empty>
       getAddProductToProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AddProductToProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
           com.google.protobuf.Empty>
       getAddProductToProductSetMethod() {
-    return getAddProductToProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
-          com.google.protobuf.Empty>
-      getAddProductToProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
             com.google.protobuf.Empty>
@@ -896,9 +725,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch",
-                              "AddProductToProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "AddProductToProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -916,30 +743,20 @@ public final class ProductSearchGrpc {
     return getAddProductToProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRemoveProductFromProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
-          com.google.protobuf.Empty>
-      METHOD_REMOVE_PRODUCT_FROM_PRODUCT_SET = getRemoveProductFromProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
           com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RemoveProductFromProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
           com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod() {
-    return getRemoveProductFromProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
-          com.google.protobuf.Empty>
-      getRemoveProductFromProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
             com.google.protobuf.Empty>
@@ -959,9 +776,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch",
-                              "RemoveProductFromProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "RemoveProductFromProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -979,30 +794,20 @@ public final class ProductSearchGrpc {
     return getRemoveProductFromProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsInProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
-      METHOD_LIST_PRODUCTS_IN_PRODUCT_SET = getListProductsInProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductsInProductSet",
+      requestType = com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod() {
-    return getListProductsInProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
-      getListProductsInProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
             com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
@@ -1021,9 +826,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch",
-                              "ListProductsInProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "ListProductsInProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1042,30 +845,20 @@ public final class ProductSearchGrpc {
     return getListProductsInProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
-          com.google.longrunning.Operation>
-      METHOD_IMPORT_PRODUCT_SETS = getImportProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
           com.google.longrunning.Operation>
       getImportProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportProductSets",
+      requestType = com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
           com.google.longrunning.Operation>
       getImportProductSetsMethod() {
-    return getImportProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
-          com.google.longrunning.Operation>
-      getImportProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
             com.google.longrunning.Operation>
@@ -1080,9 +873,7 @@ public final class ProductSearchGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p3beta1.ProductSearch", "ImportProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1102,19 +893,43 @@ public final class ProductSearchGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ProductSearchStub newStub(io.grpc.Channel channel) {
-    return new ProductSearchStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub>() {
+          @java.lang.Override
+          public ProductSearchStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchStub(channel, callOptions);
+          }
+        };
+    return ProductSearchStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ProductSearchBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ProductSearchBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub>() {
+          @java.lang.Override
+          public ProductSearchBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchBlockingStub(channel, callOptions);
+          }
+        };
+    return ProductSearchBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ProductSearchFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ProductSearchFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub>() {
+          @java.lang.Override
+          public ProductSearchFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchFutureStub(channel, callOptions);
+          }
+        };
+    return ProductSearchFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1149,7 +964,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.CreateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1166,7 +981,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.ListProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductSetsMethod(), responseObserver);
     }
 
     /**
@@ -1182,7 +997,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.GetProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1201,7 +1016,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1218,7 +1033,7 @@ public final class ProductSearchGrpc {
     public void deleteProductSet(
         com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1236,7 +1051,7 @@ public final class ProductSearchGrpc {
     public void createProduct(
         com.google.cloud.vision.v1p3beta1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductMethod(), responseObserver);
     }
 
     /**
@@ -1252,7 +1067,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.ListProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListProductsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsMethod(), responseObserver);
     }
 
     /**
@@ -1267,7 +1082,7 @@ public final class ProductSearchGrpc {
     public void getProduct(
         com.google.cloud.vision.v1p3beta1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductMethod(), responseObserver);
     }
 
     /**
@@ -1290,7 +1105,7 @@ public final class ProductSearchGrpc {
     public void updateProduct(
         com.google.cloud.vision.v1p3beta1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductMethod(), responseObserver);
     }
 
     /**
@@ -1308,7 +1123,7 @@ public final class ProductSearchGrpc {
     public void deleteProduct(
         com.google.cloud.vision.v1p3beta1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductMethod(), responseObserver);
     }
 
     /**
@@ -1336,7 +1151,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ReferenceImage>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1355,7 +1170,7 @@ public final class ProductSearchGrpc {
     public void deleteReferenceImage(
         com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1373,7 +1188,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListReferenceImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListReferenceImagesMethod(), responseObserver);
     }
 
     /**
@@ -1389,7 +1204,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ReferenceImage>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1406,7 +1221,7 @@ public final class ProductSearchGrpc {
     public void addProductToProductSet(
         com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getAddProductToProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAddProductToProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1421,7 +1236,7 @@ public final class ProductSearchGrpc {
     public void removeProductFromProductSet(
         com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1440,7 +1255,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsInProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsInProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1461,125 +1276,125 @@ public final class ProductSearchGrpc {
     public void importProductSets(
         com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportProductSetsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateProductSetMethodHelper(),
+              getCreateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.CreateProductSetRequest,
                       com.google.cloud.vision.v1p3beta1.ProductSet>(
                       this, METHODID_CREATE_PRODUCT_SET)))
           .addMethod(
-              getListProductSetsMethodHelper(),
+              getListProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.ListProductSetsRequest,
                       com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>(
                       this, METHODID_LIST_PRODUCT_SETS)))
           .addMethod(
-              getGetProductSetMethodHelper(),
+              getGetProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.GetProductSetRequest,
                       com.google.cloud.vision.v1p3beta1.ProductSet>(
                       this, METHODID_GET_PRODUCT_SET)))
           .addMethod(
-              getUpdateProductSetMethodHelper(),
+              getUpdateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest,
                       com.google.cloud.vision.v1p3beta1.ProductSet>(
                       this, METHODID_UPDATE_PRODUCT_SET)))
           .addMethod(
-              getDeleteProductSetMethodHelper(),
+              getDeleteProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_PRODUCT_SET)))
           .addMethod(
-              getCreateProductMethodHelper(),
+              getCreateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.CreateProductRequest,
                       com.google.cloud.vision.v1p3beta1.Product>(this, METHODID_CREATE_PRODUCT)))
           .addMethod(
-              getListProductsMethodHelper(),
+              getListProductsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.ListProductsRequest,
                       com.google.cloud.vision.v1p3beta1.ListProductsResponse>(
                       this, METHODID_LIST_PRODUCTS)))
           .addMethod(
-              getGetProductMethodHelper(),
+              getGetProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.GetProductRequest,
                       com.google.cloud.vision.v1p3beta1.Product>(this, METHODID_GET_PRODUCT)))
           .addMethod(
-              getUpdateProductMethodHelper(),
+              getUpdateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.UpdateProductRequest,
                       com.google.cloud.vision.v1p3beta1.Product>(this, METHODID_UPDATE_PRODUCT)))
           .addMethod(
-              getDeleteProductMethodHelper(),
+              getDeleteProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.DeleteProductRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_PRODUCT)))
           .addMethod(
-              getCreateReferenceImageMethodHelper(),
+              getCreateReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest,
                       com.google.cloud.vision.v1p3beta1.ReferenceImage>(
                       this, METHODID_CREATE_REFERENCE_IMAGE)))
           .addMethod(
-              getDeleteReferenceImageMethodHelper(),
+              getDeleteReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_REFERENCE_IMAGE)))
           .addMethod(
-              getListReferenceImagesMethodHelper(),
+              getListReferenceImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest,
                       com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>(
                       this, METHODID_LIST_REFERENCE_IMAGES)))
           .addMethod(
-              getGetReferenceImageMethodHelper(),
+              getGetReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest,
                       com.google.cloud.vision.v1p3beta1.ReferenceImage>(
                       this, METHODID_GET_REFERENCE_IMAGE)))
           .addMethod(
-              getAddProductToProductSetMethodHelper(),
+              getAddProductToProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_ADD_PRODUCT_TO_PRODUCT_SET)))
           .addMethod(
-              getRemoveProductFromProductSetMethodHelper(),
+              getRemoveProductFromProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_REMOVE_PRODUCT_FROM_PRODUCT_SET)))
           .addMethod(
-              getListProductsInProductSetMethodHelper(),
+              getListProductsInProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest,
                       com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>(
                       this, METHODID_LIST_PRODUCTS_IN_PRODUCT_SET)))
           .addMethod(
-              getImportProductSetsMethodHelper(),
+              getImportProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest,
@@ -1604,11 +1419,8 @@ public final class ProductSearchGrpc {
    *   `projects/&#42;&#47;locations/&#42;&#47;products/&#42;&#47;referenceImages/&#42;`
    * </pre>
    */
-  public static final class ProductSearchStub extends io.grpc.stub.AbstractStub<ProductSearchStub> {
-    private ProductSearchStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class ProductSearchStub
+      extends io.grpc.stub.AbstractAsyncStub<ProductSearchStub> {
     private ProductSearchStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1633,7 +1445,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1653,7 +1465,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1672,7 +1484,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1694,7 +1506,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1714,7 +1526,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1735,7 +1547,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1754,7 +1566,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListProductsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1772,9 +1584,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1798,7 +1608,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1819,7 +1629,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1850,7 +1660,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ReferenceImage>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1872,7 +1682,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1893,7 +1703,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1912,7 +1722,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p3beta1.ReferenceImage>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1932,7 +1742,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1950,7 +1760,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1972,7 +1782,7 @@ public final class ProductSearchGrpc {
                 com.google.cloud.vision.v1p3beta1.ListProductsInProductSetResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1996,7 +1806,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2019,11 +1829,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchBlockingStub
-      extends io.grpc.stub.AbstractStub<ProductSearchBlockingStub> {
-    private ProductSearchBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ProductSearchBlockingStub> {
     private ProductSearchBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2047,7 +1853,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p3beta1.ProductSet createProductSet(
         com.google.cloud.vision.v1p3beta1.CreateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2062,8 +1868,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.ListProductSetsResponse listProductSets(
         com.google.cloud.vision.v1p3beta1.ListProductSetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductSetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductSetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2077,8 +1882,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.ProductSet getProductSet(
         com.google.cloud.vision.v1p3beta1.GetProductSetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductSetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2096,7 +1900,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p3beta1.ProductSet updateProductSet(
         com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2113,7 +1917,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteProductSet(
         com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2130,8 +1934,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.Product createProduct(
         com.google.cloud.vision.v1p3beta1.CreateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2145,8 +1948,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.ListProductsResponse listProducts(
         com.google.cloud.vision.v1p3beta1.ListProductsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2160,8 +1962,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.Product getProduct(
         com.google.cloud.vision.v1p3beta1.GetProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2183,8 +1984,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p3beta1.Product updateProduct(
         com.google.cloud.vision.v1p3beta1.UpdateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2201,8 +2001,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.protobuf.Empty deleteProduct(
         com.google.cloud.vision.v1p3beta1.DeleteProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2229,7 +2028,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p3beta1.ReferenceImage createReferenceImage(
         com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2248,7 +2047,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteReferenceImage(
         com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2265,7 +2064,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse listReferenceImages(
         com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListReferenceImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListReferenceImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2280,7 +2079,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p3beta1.ReferenceImage getReferenceImage(
         com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2297,7 +2096,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty addProductToProductSet(
         com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAddProductToProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getAddProductToProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2312,7 +2111,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty removeProductFromProductSet(
         com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRemoveProductFromProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getRemoveProductFromProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2330,7 +2129,7 @@ public final class ProductSearchGrpc {
         listProductsInProductSet(
             com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListProductsInProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getListProductsInProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2351,7 +2150,7 @@ public final class ProductSearchGrpc {
     public com.google.longrunning.Operation importProductSets(
         com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getImportProductSetsMethodHelper(), getCallOptions(), request);
+          getChannel(), getImportProductSetsMethod(), getCallOptions(), request);
     }
   }
 
@@ -2372,11 +2171,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchFutureStub
-      extends io.grpc.stub.AbstractStub<ProductSearchFutureStub> {
-    private ProductSearchFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ProductSearchFutureStub> {
     private ProductSearchFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2401,7 +2196,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ProductSet>
         createProductSet(com.google.cloud.vision.v1p3beta1.CreateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2418,7 +2213,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ListProductSetsResponse>
         listProductSets(com.google.cloud.vision.v1p3beta1.ListProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2434,7 +2229,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ProductSet>
         getProductSet(com.google.cloud.vision.v1p3beta1.GetProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2453,7 +2248,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ProductSet>
         updateProductSet(com.google.cloud.vision.v1p3beta1.UpdateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2470,7 +2265,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProductSet(com.google.cloud.vision.v1p3beta1.DeleteProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2489,7 +2284,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.Product>
         createProduct(com.google.cloud.vision.v1p3beta1.CreateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2505,7 +2300,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ListProductsResponse>
         listProducts(com.google.cloud.vision.v1p3beta1.ListProductsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2521,7 +2316,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.Product>
         getProduct(com.google.cloud.vision.v1p3beta1.GetProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2545,7 +2340,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.Product>
         updateProduct(com.google.cloud.vision.v1p3beta1.UpdateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2563,7 +2358,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProduct(com.google.cloud.vision.v1p3beta1.DeleteProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2592,7 +2387,7 @@ public final class ProductSearchGrpc {
         createReferenceImage(
             com.google.cloud.vision.v1p3beta1.CreateReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2612,7 +2407,7 @@ public final class ProductSearchGrpc {
         deleteReferenceImage(
             com.google.cloud.vision.v1p3beta1.DeleteReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2630,7 +2425,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ListReferenceImagesResponse>
         listReferenceImages(com.google.cloud.vision.v1p3beta1.ListReferenceImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2646,7 +2441,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p3beta1.ReferenceImage>
         getReferenceImage(com.google.cloud.vision.v1p3beta1.GetReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2664,7 +2459,7 @@ public final class ProductSearchGrpc {
         addProductToProductSet(
             com.google.cloud.vision.v1p3beta1.AddProductToProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2680,8 +2475,7 @@ public final class ProductSearchGrpc {
         removeProductFromProductSet(
             com.google.cloud.vision.v1p3beta1.RemoveProductFromProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2700,8 +2494,7 @@ public final class ProductSearchGrpc {
         listProductsInProductSet(
             com.google.cloud.vision.v1p3beta1.ListProductsInProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2722,7 +2515,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importProductSets(com.google.cloud.vision.v1p3beta1.ImportProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()), request);
     }
   }
 
@@ -2931,24 +2724,24 @@ public final class ProductSearchGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ProductSearchFileDescriptorSupplier())
-                      .addMethod(getCreateProductSetMethodHelper())
-                      .addMethod(getListProductSetsMethodHelper())
-                      .addMethod(getGetProductSetMethodHelper())
-                      .addMethod(getUpdateProductSetMethodHelper())
-                      .addMethod(getDeleteProductSetMethodHelper())
-                      .addMethod(getCreateProductMethodHelper())
-                      .addMethod(getListProductsMethodHelper())
-                      .addMethod(getGetProductMethodHelper())
-                      .addMethod(getUpdateProductMethodHelper())
-                      .addMethod(getDeleteProductMethodHelper())
-                      .addMethod(getCreateReferenceImageMethodHelper())
-                      .addMethod(getDeleteReferenceImageMethodHelper())
-                      .addMethod(getListReferenceImagesMethodHelper())
-                      .addMethod(getGetReferenceImageMethodHelper())
-                      .addMethod(getAddProductToProductSetMethodHelper())
-                      .addMethod(getRemoveProductFromProductSetMethodHelper())
-                      .addMethod(getListProductsInProductSetMethodHelper())
-                      .addMethod(getImportProductSetsMethodHelper())
+                      .addMethod(getCreateProductSetMethod())
+                      .addMethod(getListProductSetsMethod())
+                      .addMethod(getGetProductSetMethod())
+                      .addMethod(getUpdateProductSetMethod())
+                      .addMethod(getDeleteProductSetMethod())
+                      .addMethod(getCreateProductMethod())
+                      .addMethod(getListProductsMethod())
+                      .addMethod(getGetProductMethod())
+                      .addMethod(getUpdateProductMethod())
+                      .addMethod(getDeleteProductMethod())
+                      .addMethod(getCreateReferenceImageMethod())
+                      .addMethod(getDeleteReferenceImageMethod())
+                      .addMethod(getListReferenceImagesMethod())
+                      .addMethod(getGetReferenceImageMethod())
+                      .addMethod(getAddProductToProductSetMethod())
+                      .addMethod(getRemoveProductFromProductSetMethod())
+                      .addMethod(getListProductsInProductSetMethod())
+                      .addMethod(getImportProductSetsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p4beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-vision-v1p4beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/vision/v1p4beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-vision-v1p4beta1/src/main/java/com/google/cloud/vision/v1p4beta1/ImageAnnotatorGrpc.java
+++ b/grpc-google-cloud-vision-v1p4beta1/src/main/java/com/google/cloud/vision/v1p4beta1/ImageAnnotatorGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p4beta1/image_annotator.proto")
 public final class ImageAnnotatorGrpc {
 
@@ -41,30 +41,20 @@ public final class ImageAnnotatorGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p4beta1.ImageAnnotator";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
-      METHOD_BATCH_ANNOTATE_IMAGES = getBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
           com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
       getBatchAnnotateImagesMethod() {
-    return getBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
-      getBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
             com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
@@ -81,9 +71,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ImageAnnotator",
-                              "BatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "BatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -102,30 +90,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
-      METHOD_BATCH_ANNOTATE_FILES = getBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
           com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
       getBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
           com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
       getBatchAnnotateFilesMethod() {
-    return getBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
-          com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
-      getBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
             com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
@@ -141,9 +119,7 @@ public final class ImageAnnotatorGrpc {
                           com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ImageAnnotator", "BatchAnnotateFiles"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -162,30 +138,20 @@ public final class ImageAnnotatorGrpc {
     return getBatchAnnotateFilesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_IMAGES = getAsyncBatchAnnotateImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateImages",
+      requestType = com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateImagesMethod() {
-    return getAsyncBatchAnnotateImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
             com.google.longrunning.Operation>
@@ -204,9 +170,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ImageAnnotator",
-                              "AsyncBatchAnnotateImages"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -224,30 +188,20 @@ public final class ImageAnnotatorGrpc {
     return getAsyncBatchAnnotateImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAsyncBatchAnnotateFilesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      METHOD_ASYNC_BATCH_ANNOTATE_FILES = getAsyncBatchAnnotateFilesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AsyncBatchAnnotateFiles",
+      requestType = com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
           com.google.longrunning.Operation>
       getAsyncBatchAnnotateFilesMethod() {
-    return getAsyncBatchAnnotateFilesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
-          com.google.longrunning.Operation>
-      getAsyncBatchAnnotateFilesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
             com.google.longrunning.Operation>
@@ -265,9 +219,7 @@ public final class ImageAnnotatorGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ImageAnnotator",
-                              "AsyncBatchAnnotateFiles"))
+                          generateFullMethodName(SERVICE_NAME, "AsyncBatchAnnotateFiles"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -287,19 +239,43 @@ public final class ImageAnnotatorGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ImageAnnotatorStub newStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorStub>() {
+          @java.lang.Override
+          public ImageAnnotatorStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ImageAnnotatorBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorBlockingStub>() {
+          @java.lang.Override
+          public ImageAnnotatorBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorBlockingStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ImageAnnotatorFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ImageAnnotatorFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ImageAnnotatorFutureStub>() {
+          @java.lang.Override
+          public ImageAnnotatorFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ImageAnnotatorFutureStub(channel, callOptions);
+          }
+        };
+    return ImageAnnotatorFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -324,7 +300,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -343,7 +319,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchAnnotateFilesMethod(), responseObserver);
     }
 
     /**
@@ -362,7 +338,7 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateImages(
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateImagesMethod(), responseObserver);
     }
 
     /**
@@ -380,35 +356,35 @@ public final class ImageAnnotatorGrpc {
     public void asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAsyncBatchAnnotateFilesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getBatchAnnotateImagesMethodHelper(),
+              getBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest,
                       com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>(
                       this, METHODID_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getBatchAnnotateFilesMethodHelper(),
+              getBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest,
                       com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>(
                       this, METHODID_BATCH_ANNOTATE_FILES)))
           .addMethod(
-              getAsyncBatchAnnotateImagesMethodHelper(),
+              getAsyncBatchAnnotateImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_ASYNC_BATCH_ANNOTATE_IMAGES)))
           .addMethod(
-              getAsyncBatchAnnotateFilesMethodHelper(),
+              getAsyncBatchAnnotateFilesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest,
@@ -427,11 +403,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorStub> {
-    private ImageAnnotatorStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ImageAnnotatorStub> {
     private ImageAnnotatorStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -453,7 +425,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -475,7 +447,7 @@ public final class ImageAnnotatorGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -497,7 +469,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -518,7 +490,7 @@ public final class ImageAnnotatorGrpc {
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -534,11 +506,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorBlockingStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorBlockingStub> {
-    private ImageAnnotatorBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ImageAnnotatorBlockingStub> {
     private ImageAnnotatorBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -559,7 +527,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse batchAnnotateImages(
         com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -577,7 +545,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse batchAnnotateFiles(
         com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -596,7 +564,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateImages(
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -614,7 +582,7 @@ public final class ImageAnnotatorGrpc {
     public com.google.longrunning.Operation asyncBatchAnnotateFiles(
         com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions(), request);
+          getChannel(), getAsyncBatchAnnotateFilesMethod(), getCallOptions(), request);
     }
   }
 
@@ -628,11 +596,7 @@ public final class ImageAnnotatorGrpc {
    * </pre>
    */
   public static final class ImageAnnotatorFutureStub
-      extends io.grpc.stub.AbstractStub<ImageAnnotatorFutureStub> {
-    private ImageAnnotatorFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ImageAnnotatorFutureStub> {
     private ImageAnnotatorFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -654,7 +618,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesResponse>
         batchAnnotateImages(com.google.cloud.vision.v1p4beta1.BatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -673,7 +637,7 @@ public final class ImageAnnotatorGrpc {
             com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesResponse>
         batchAnnotateFiles(com.google.cloud.vision.v1p4beta1.BatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchAnnotateFilesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -693,8 +657,7 @@ public final class ImageAnnotatorGrpc {
         asyncBatchAnnotateImages(
             com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateImagesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -713,8 +676,7 @@ public final class ImageAnnotatorGrpc {
         asyncBatchAnnotateFiles(
             com.google.cloud.vision.v1p4beta1.AsyncBatchAnnotateFilesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAsyncBatchAnnotateFilesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getAsyncBatchAnnotateFilesMethod(), getCallOptions()), request);
     }
   }
 
@@ -828,10 +790,10 @@ public final class ImageAnnotatorGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ImageAnnotatorFileDescriptorSupplier())
-                      .addMethod(getBatchAnnotateImagesMethodHelper())
-                      .addMethod(getBatchAnnotateFilesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateImagesMethodHelper())
-                      .addMethod(getAsyncBatchAnnotateFilesMethodHelper())
+                      .addMethod(getBatchAnnotateImagesMethod())
+                      .addMethod(getBatchAnnotateFilesMethod())
+                      .addMethod(getAsyncBatchAnnotateImagesMethod())
+                      .addMethod(getAsyncBatchAnnotateFilesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-vision-v1p4beta1/src/main/java/com/google/cloud/vision/v1p4beta1/ProductSearchGrpc.java
+++ b/grpc-google-cloud-vision-v1p4beta1/src/main/java/com/google/cloud/vision/v1p4beta1/ProductSearchGrpc.java
@@ -43,7 +43,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/vision/v1p4beta1/product_search_service.proto")
 public final class ProductSearchGrpc {
 
@@ -52,30 +52,20 @@ public final class ProductSearchGrpc {
   public static final String SERVICE_NAME = "google.cloud.vision.v1p4beta1.ProductSearch";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      METHOD_CREATE_PRODUCT_SET = getCreateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getCreateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.CreateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getCreateProductSetMethod() {
-    return getCreateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      getCreateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
             com.google.cloud.vision.v1p4beta1.ProductSet>
@@ -90,9 +80,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "CreateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -110,30 +98,20 @@ public final class ProductSearchGrpc {
     return getCreateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
-      METHOD_LIST_PRODUCT_SETS = getListProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
           com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
       getListProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductSets",
+      requestType = com.google.cloud.vision.v1p4beta1.ListProductSetsRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ListProductSetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
           com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
       getListProductSetsMethod() {
-    return getListProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
-      getListProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
             com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
@@ -148,9 +126,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "ListProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -169,30 +145,20 @@ public final class ProductSearchGrpc {
     return getListProductSetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      METHOD_GET_PRODUCT_SET = getGetProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getGetProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.GetProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getGetProductSetMethod() {
-    return getGetProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      getGetProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
             com.google.cloud.vision.v1p4beta1.ProductSet>
@@ -207,9 +173,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "GetProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -227,30 +191,20 @@ public final class ProductSearchGrpc {
     return getGetProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      METHOD_UPDATE_PRODUCT_SET = getUpdateProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getUpdateProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ProductSet.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ProductSet>
       getUpdateProductSetMethod() {
-    return getUpdateProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ProductSet>
-      getUpdateProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
             com.google.cloud.vision.v1p4beta1.ProductSet>
@@ -265,9 +219,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ProductSet>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "UpdateProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -285,26 +237,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT_SET = getDeleteProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
       getDeleteProductSetMethod() {
-    return getDeleteProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
-      getDeleteProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest, com.google.protobuf.Empty>
         getDeleteProductSetMethod;
@@ -318,9 +262,7 @@ public final class ProductSearchGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "DeleteProductSet"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -338,30 +280,20 @@ public final class ProductSearchGrpc {
     return getDeleteProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      METHOD_CREATE_PRODUCT = getCreateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getCreateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateProduct",
+      requestType = com.google.cloud.vision.v1p4beta1.CreateProductRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getCreateProductMethod() {
-    return getCreateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      getCreateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.CreateProductRequest,
             com.google.cloud.vision.v1p4beta1.Product>
@@ -376,9 +308,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "CreateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -396,30 +326,20 @@ public final class ProductSearchGrpc {
     return getCreateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductsRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductsResponse>
-      METHOD_LIST_PRODUCTS = getListProductsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductsRequest,
           com.google.cloud.vision.v1p4beta1.ListProductsResponse>
       getListProductsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProducts",
+      requestType = com.google.cloud.vision.v1p4beta1.ListProductsRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ListProductsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductsRequest,
           com.google.cloud.vision.v1p4beta1.ListProductsResponse>
       getListProductsMethod() {
-    return getListProductsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductsRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductsResponse>
-      getListProductsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.ListProductsRequest,
             com.google.cloud.vision.v1p4beta1.ListProductsResponse>
@@ -434,9 +354,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ListProductsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "ListProducts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListProducts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -455,30 +373,20 @@ public final class ProductSearchGrpc {
     return getListProductsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      METHOD_GET_PRODUCT = getGetProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getGetProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetProduct",
+      requestType = com.google.cloud.vision.v1p4beta1.GetProductRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getGetProductMethod() {
-    return getGetProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      getGetProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.GetProductRequest,
             com.google.cloud.vision.v1p4beta1.Product>
@@ -493,9 +401,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "GetProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -512,30 +418,20 @@ public final class ProductSearchGrpc {
     return getGetProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      METHOD_UPDATE_PRODUCT = getUpdateProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getUpdateProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateProduct",
+      requestType = com.google.cloud.vision.v1p4beta1.UpdateProductRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.Product.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
           com.google.cloud.vision.v1p4beta1.Product>
       getUpdateProductMethod() {
-    return getUpdateProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
-          com.google.cloud.vision.v1p4beta1.Product>
-      getUpdateProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
             com.google.cloud.vision.v1p4beta1.Product>
@@ -550,9 +446,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.Product>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "UpdateProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -570,26 +464,18 @@ public final class ProductSearchGrpc {
     return getUpdateProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteProductMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteProductRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_PRODUCT = getDeleteProductMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteProduct",
+      requestType = com.google.cloud.vision.v1p4beta1.DeleteProductRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteProductRequest, com.google.protobuf.Empty>
       getDeleteProductMethod() {
-    return getDeleteProductMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteProductRequest, com.google.protobuf.Empty>
-      getDeleteProductMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.DeleteProductRequest, com.google.protobuf.Empty>
         getDeleteProductMethod;
@@ -603,9 +489,7 @@ public final class ProductSearchGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "DeleteProduct"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteProduct"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -623,30 +507,20 @@ public final class ProductSearchGrpc {
     return getDeleteProductMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1p4beta1.ReferenceImage>
-      METHOD_CREATE_REFERENCE_IMAGE = getCreateReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1p4beta1.ReferenceImage>
       getCreateReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateReferenceImage",
+      requestType = com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
           com.google.cloud.vision.v1p4beta1.ReferenceImage>
       getCreateReferenceImageMethod() {
-    return getCreateReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
-          com.google.cloud.vision.v1p4beta1.ReferenceImage>
-      getCreateReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
             com.google.cloud.vision.v1p4beta1.ReferenceImage>
@@ -663,9 +537,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch",
-                              "CreateReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "CreateReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -684,26 +556,18 @@ public final class ProductSearchGrpc {
     return getCreateReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_REFERENCE_IMAGE = getDeleteReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteReferenceImage",
+      requestType = com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
       getDeleteReferenceImageMethod() {
-    return getDeleteReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest, com.google.protobuf.Empty>
-      getDeleteReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest,
             com.google.protobuf.Empty>
@@ -720,9 +584,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch",
-                              "DeleteReferenceImage"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -740,30 +602,20 @@ public final class ProductSearchGrpc {
     return getDeleteReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListReferenceImagesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
-      METHOD_LIST_REFERENCE_IMAGES = getListReferenceImagesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
       getListReferenceImagesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListReferenceImages",
+      requestType = com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
           com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
       getListReferenceImagesMethod() {
-    return getListReferenceImagesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
-          com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
-      getListReferenceImagesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
             com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
@@ -780,8 +632,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "ListReferenceImages"))
+                          generateFullMethodName(SERVICE_NAME, "ListReferenceImages"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -800,30 +651,20 @@ public final class ProductSearchGrpc {
     return getListReferenceImagesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetReferenceImageMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1p4beta1.ReferenceImage>
-      METHOD_GET_REFERENCE_IMAGE = getGetReferenceImageMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
           com.google.cloud.vision.v1p4beta1.ReferenceImage>
       getGetReferenceImageMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetReferenceImage",
+      requestType = com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ReferenceImage.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
           com.google.cloud.vision.v1p4beta1.ReferenceImage>
       getGetReferenceImageMethod() {
-    return getGetReferenceImageMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
-          com.google.cloud.vision.v1p4beta1.ReferenceImage>
-      getGetReferenceImageMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
             com.google.cloud.vision.v1p4beta1.ReferenceImage>
@@ -838,9 +679,7 @@ public final class ProductSearchGrpc {
                           com.google.cloud.vision.v1p4beta1.ReferenceImage>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "GetReferenceImage"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetReferenceImage"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -859,30 +698,20 @@ public final class ProductSearchGrpc {
     return getGetReferenceImageMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAddProductToProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
-          com.google.protobuf.Empty>
-      METHOD_ADD_PRODUCT_TO_PRODUCT_SET = getAddProductToProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
           com.google.protobuf.Empty>
       getAddProductToProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AddProductToProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
           com.google.protobuf.Empty>
       getAddProductToProductSetMethod() {
-    return getAddProductToProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
-          com.google.protobuf.Empty>
-      getAddProductToProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
             com.google.protobuf.Empty>
@@ -900,9 +729,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch",
-                              "AddProductToProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "AddProductToProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -920,30 +747,20 @@ public final class ProductSearchGrpc {
     return getAddProductToProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRemoveProductFromProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
-          com.google.protobuf.Empty>
-      METHOD_REMOVE_PRODUCT_FROM_PRODUCT_SET = getRemoveProductFromProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
           com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RemoveProductFromProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
           com.google.protobuf.Empty>
       getRemoveProductFromProductSetMethod() {
-    return getRemoveProductFromProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
-          com.google.protobuf.Empty>
-      getRemoveProductFromProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
             com.google.protobuf.Empty>
@@ -963,9 +780,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch",
-                              "RemoveProductFromProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "RemoveProductFromProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -983,30 +798,20 @@ public final class ProductSearchGrpc {
     return getRemoveProductFromProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListProductsInProductSetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
-      METHOD_LIST_PRODUCTS_IN_PRODUCT_SET = getListProductsInProductSetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListProductsInProductSet",
+      requestType = com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest.class,
+      responseType = com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
           com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
       getListProductsInProductSetMethod() {
-    return getListProductsInProductSetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
-          com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
-      getListProductsInProductSetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
             com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
@@ -1025,9 +830,7 @@ public final class ProductSearchGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch",
-                              "ListProductsInProductSet"))
+                          generateFullMethodName(SERVICE_NAME, "ListProductsInProductSet"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1046,30 +849,20 @@ public final class ProductSearchGrpc {
     return getListProductsInProductSetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportProductSetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
-          com.google.longrunning.Operation>
-      METHOD_IMPORT_PRODUCT_SETS = getImportProductSetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
           com.google.longrunning.Operation>
       getImportProductSetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportProductSets",
+      requestType = com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
           com.google.longrunning.Operation>
       getImportProductSetsMethod() {
-    return getImportProductSetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
-          com.google.longrunning.Operation>
-      getImportProductSetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
             com.google.longrunning.Operation>
@@ -1084,9 +877,7 @@ public final class ProductSearchGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "ImportProductSets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportProductSets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1104,26 +895,18 @@ public final class ProductSearchGrpc {
     return getImportProductSetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getPurgeProductsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.PurgeProductsRequest, com.google.longrunning.Operation>
-      METHOD_PURGE_PRODUCTS = getPurgeProductsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.PurgeProductsRequest, com.google.longrunning.Operation>
       getPurgeProductsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "PurgeProducts",
+      requestType = com.google.cloud.vision.v1p4beta1.PurgeProductsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.vision.v1p4beta1.PurgeProductsRequest, com.google.longrunning.Operation>
       getPurgeProductsMethod() {
-    return getPurgeProductsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.vision.v1p4beta1.PurgeProductsRequest, com.google.longrunning.Operation>
-      getPurgeProductsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.vision.v1p4beta1.PurgeProductsRequest,
             com.google.longrunning.Operation>
@@ -1138,9 +921,7 @@ public final class ProductSearchGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.vision.v1p4beta1.ProductSearch", "PurgeProducts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "PurgeProducts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1160,19 +941,43 @@ public final class ProductSearchGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ProductSearchStub newStub(io.grpc.Channel channel) {
-    return new ProductSearchStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchStub>() {
+          @java.lang.Override
+          public ProductSearchStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchStub(channel, callOptions);
+          }
+        };
+    return ProductSearchStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ProductSearchBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ProductSearchBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchBlockingStub>() {
+          @java.lang.Override
+          public ProductSearchBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchBlockingStub(channel, callOptions);
+          }
+        };
+    return ProductSearchBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ProductSearchFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ProductSearchFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ProductSearchFutureStub>() {
+          @java.lang.Override
+          public ProductSearchFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ProductSearchFutureStub(channel, callOptions);
+          }
+        };
+    return ProductSearchFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1211,7 +1016,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.CreateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1228,7 +1033,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.ListProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductSetsMethod(), responseObserver);
     }
 
     /**
@@ -1244,7 +1049,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.GetProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1263,7 +1068,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1278,7 +1083,7 @@ public final class ProductSearchGrpc {
     public void deleteProductSet(
         com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1296,7 +1101,7 @@ public final class ProductSearchGrpc {
     public void createProduct(
         com.google.cloud.vision.v1p4beta1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateProductMethod(), responseObserver);
     }
 
     /**
@@ -1312,7 +1117,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.ListProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListProductsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsMethod(), responseObserver);
     }
 
     /**
@@ -1327,7 +1132,7 @@ public final class ProductSearchGrpc {
     public void getProduct(
         com.google.cloud.vision.v1p4beta1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetProductMethod(), responseObserver);
     }
 
     /**
@@ -1351,7 +1156,7 @@ public final class ProductSearchGrpc {
     public void updateProduct(
         com.google.cloud.vision.v1p4beta1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateProductMethod(), responseObserver);
     }
 
     /**
@@ -1367,7 +1172,7 @@ public final class ProductSearchGrpc {
     public void deleteProduct(
         com.google.cloud.vision.v1p4beta1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteProductMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteProductMethod(), responseObserver);
     }
 
     /**
@@ -1395,7 +1200,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ReferenceImage>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1412,7 +1217,7 @@ public final class ProductSearchGrpc {
     public void deleteReferenceImage(
         com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1430,7 +1235,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListReferenceImagesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListReferenceImagesMethod(), responseObserver);
     }
 
     /**
@@ -1446,7 +1251,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ReferenceImage>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetReferenceImageMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetReferenceImageMethod(), responseObserver);
     }
 
     /**
@@ -1463,7 +1268,7 @@ public final class ProductSearchGrpc {
     public void addProductToProductSet(
         com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getAddProductToProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAddProductToProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1476,7 +1281,7 @@ public final class ProductSearchGrpc {
     public void removeProductFromProductSet(
         com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRemoveProductFromProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1495,7 +1300,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListProductsInProductSetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListProductsInProductSetMethod(), responseObserver);
     }
 
     /**
@@ -1516,7 +1321,7 @@ public final class ProductSearchGrpc {
     public void importProductSets(
         com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportProductSetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportProductSetsMethod(), responseObserver);
     }
 
     /**
@@ -1547,131 +1352,131 @@ public final class ProductSearchGrpc {
     public void purgeProducts(
         com.google.cloud.vision.v1p4beta1.PurgeProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getPurgeProductsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getPurgeProductsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateProductSetMethodHelper(),
+              getCreateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.CreateProductSetRequest,
                       com.google.cloud.vision.v1p4beta1.ProductSet>(
                       this, METHODID_CREATE_PRODUCT_SET)))
           .addMethod(
-              getListProductSetsMethodHelper(),
+              getListProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.ListProductSetsRequest,
                       com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>(
                       this, METHODID_LIST_PRODUCT_SETS)))
           .addMethod(
-              getGetProductSetMethodHelper(),
+              getGetProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.GetProductSetRequest,
                       com.google.cloud.vision.v1p4beta1.ProductSet>(
                       this, METHODID_GET_PRODUCT_SET)))
           .addMethod(
-              getUpdateProductSetMethodHelper(),
+              getUpdateProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest,
                       com.google.cloud.vision.v1p4beta1.ProductSet>(
                       this, METHODID_UPDATE_PRODUCT_SET)))
           .addMethod(
-              getDeleteProductSetMethodHelper(),
+              getDeleteProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_PRODUCT_SET)))
           .addMethod(
-              getCreateProductMethodHelper(),
+              getCreateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.CreateProductRequest,
                       com.google.cloud.vision.v1p4beta1.Product>(this, METHODID_CREATE_PRODUCT)))
           .addMethod(
-              getListProductsMethodHelper(),
+              getListProductsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.ListProductsRequest,
                       com.google.cloud.vision.v1p4beta1.ListProductsResponse>(
                       this, METHODID_LIST_PRODUCTS)))
           .addMethod(
-              getGetProductMethodHelper(),
+              getGetProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.GetProductRequest,
                       com.google.cloud.vision.v1p4beta1.Product>(this, METHODID_GET_PRODUCT)))
           .addMethod(
-              getUpdateProductMethodHelper(),
+              getUpdateProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.UpdateProductRequest,
                       com.google.cloud.vision.v1p4beta1.Product>(this, METHODID_UPDATE_PRODUCT)))
           .addMethod(
-              getDeleteProductMethodHelper(),
+              getDeleteProductMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.DeleteProductRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_PRODUCT)))
           .addMethod(
-              getCreateReferenceImageMethodHelper(),
+              getCreateReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest,
                       com.google.cloud.vision.v1p4beta1.ReferenceImage>(
                       this, METHODID_CREATE_REFERENCE_IMAGE)))
           .addMethod(
-              getDeleteReferenceImageMethodHelper(),
+              getDeleteReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_REFERENCE_IMAGE)))
           .addMethod(
-              getListReferenceImagesMethodHelper(),
+              getListReferenceImagesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest,
                       com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>(
                       this, METHODID_LIST_REFERENCE_IMAGES)))
           .addMethod(
-              getGetReferenceImageMethodHelper(),
+              getGetReferenceImageMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest,
                       com.google.cloud.vision.v1p4beta1.ReferenceImage>(
                       this, METHODID_GET_REFERENCE_IMAGE)))
           .addMethod(
-              getAddProductToProductSetMethodHelper(),
+              getAddProductToProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_ADD_PRODUCT_TO_PRODUCT_SET)))
           .addMethod(
-              getRemoveProductFromProductSetMethodHelper(),
+              getRemoveProductFromProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest,
                       com.google.protobuf.Empty>(this, METHODID_REMOVE_PRODUCT_FROM_PRODUCT_SET)))
           .addMethod(
-              getListProductsInProductSetMethodHelper(),
+              getListProductsInProductSetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest,
                       com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>(
                       this, METHODID_LIST_PRODUCTS_IN_PRODUCT_SET)))
           .addMethod(
-              getImportProductSetsMethodHelper(),
+              getImportProductSetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_PRODUCT_SETS)))
           .addMethod(
-              getPurgeProductsMethodHelper(),
+              getPurgeProductsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.vision.v1p4beta1.PurgeProductsRequest,
@@ -1700,11 +1505,8 @@ public final class ProductSearchGrpc {
    *   `projects/&#42;&#47;locations/&#42;&#47;products/&#42;&#47;referenceImages/&#42;`
    * </pre>
    */
-  public static final class ProductSearchStub extends io.grpc.stub.AbstractStub<ProductSearchStub> {
-    private ProductSearchStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class ProductSearchStub
+      extends io.grpc.stub.AbstractAsyncStub<ProductSearchStub> {
     private ProductSearchStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1729,7 +1531,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1749,7 +1551,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1768,7 +1570,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1790,7 +1592,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ProductSet>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1808,7 +1610,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1829,7 +1631,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.CreateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1848,7 +1650,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListProductsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1866,9 +1668,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.GetProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1893,7 +1693,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.UpdateProductRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.Product> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1912,7 +1712,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.DeleteProductRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1943,7 +1743,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ReferenceImage>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1963,7 +1763,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1984,7 +1784,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2003,7 +1803,7 @@ public final class ProductSearchGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.vision.v1p4beta1.ReferenceImage>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2023,7 +1823,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2039,7 +1839,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2061,7 +1861,7 @@ public final class ProductSearchGrpc {
                 com.google.cloud.vision.v1p4beta1.ListProductsInProductSetResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2085,7 +1885,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2119,7 +1919,7 @@ public final class ProductSearchGrpc {
         com.google.cloud.vision.v1p4beta1.PurgeProductsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getPurgeProductsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getPurgeProductsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2146,11 +1946,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchBlockingStub
-      extends io.grpc.stub.AbstractStub<ProductSearchBlockingStub> {
-    private ProductSearchBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ProductSearchBlockingStub> {
     private ProductSearchBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2174,7 +1970,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p4beta1.ProductSet createProductSet(
         com.google.cloud.vision.v1p4beta1.CreateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2189,8 +1985,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.ListProductSetsResponse listProductSets(
         com.google.cloud.vision.v1p4beta1.ListProductSetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductSetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductSetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2204,8 +1999,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.ProductSet getProductSet(
         com.google.cloud.vision.v1p4beta1.GetProductSetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductSetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2223,7 +2017,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p4beta1.ProductSet updateProductSet(
         com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2238,7 +2032,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteProductSet(
         com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2255,8 +2049,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.Product createProduct(
         com.google.cloud.vision.v1p4beta1.CreateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2270,8 +2063,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.ListProductsResponse listProducts(
         com.google.cloud.vision.v1p4beta1.ListProductsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListProductsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListProductsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2285,8 +2077,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.Product getProduct(
         com.google.cloud.vision.v1p4beta1.GetProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2309,8 +2100,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.cloud.vision.v1p4beta1.Product updateProduct(
         com.google.cloud.vision.v1p4beta1.UpdateProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2325,8 +2115,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.protobuf.Empty deleteProduct(
         com.google.cloud.vision.v1p4beta1.DeleteProductRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteProductMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteProductMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2353,7 +2142,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p4beta1.ReferenceImage createReferenceImage(
         com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2370,7 +2159,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty deleteReferenceImage(
         com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2387,7 +2176,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse listReferenceImages(
         com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListReferenceImagesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListReferenceImagesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2402,7 +2191,7 @@ public final class ProductSearchGrpc {
     public com.google.cloud.vision.v1p4beta1.ReferenceImage getReferenceImage(
         com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetReferenceImageMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetReferenceImageMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2419,7 +2208,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty addProductToProductSet(
         com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAddProductToProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getAddProductToProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2432,7 +2221,7 @@ public final class ProductSearchGrpc {
     public com.google.protobuf.Empty removeProductFromProductSet(
         com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRemoveProductFromProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getRemoveProductFromProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2450,7 +2239,7 @@ public final class ProductSearchGrpc {
         listProductsInProductSet(
             com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListProductsInProductSetMethodHelper(), getCallOptions(), request);
+          getChannel(), getListProductsInProductSetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2471,7 +2260,7 @@ public final class ProductSearchGrpc {
     public com.google.longrunning.Operation importProductSets(
         com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getImportProductSetsMethodHelper(), getCallOptions(), request);
+          getChannel(), getImportProductSetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2501,8 +2290,7 @@ public final class ProductSearchGrpc {
      */
     public com.google.longrunning.Operation purgeProducts(
         com.google.cloud.vision.v1p4beta1.PurgeProductsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getPurgeProductsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getPurgeProductsMethod(), getCallOptions(), request);
     }
   }
 
@@ -2527,11 +2315,7 @@ public final class ProductSearchGrpc {
    * </pre>
    */
   public static final class ProductSearchFutureStub
-      extends io.grpc.stub.AbstractStub<ProductSearchFutureStub> {
-    private ProductSearchFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ProductSearchFutureStub> {
     private ProductSearchFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2556,7 +2340,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ProductSet>
         createProductSet(com.google.cloud.vision.v1p4beta1.CreateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2573,7 +2357,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ListProductSetsResponse>
         listProductSets(com.google.cloud.vision.v1p4beta1.ListProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductSetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2589,7 +2373,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ProductSet>
         getProductSet(com.google.cloud.vision.v1p4beta1.GetProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2608,7 +2392,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ProductSet>
         updateProductSet(com.google.cloud.vision.v1p4beta1.UpdateProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2623,7 +2407,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProductSet(com.google.cloud.vision.v1p4beta1.DeleteProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2642,7 +2426,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.Product>
         createProduct(com.google.cloud.vision.v1p4beta1.CreateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2658,7 +2442,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ListProductsResponse>
         listProducts(com.google.cloud.vision.v1p4beta1.ListProductsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListProductsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2674,7 +2458,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.Product>
         getProduct(com.google.cloud.vision.v1p4beta1.GetProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2699,7 +2483,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.Product>
         updateProduct(com.google.cloud.vision.v1p4beta1.UpdateProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2715,7 +2499,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteProduct(com.google.cloud.vision.v1p4beta1.DeleteProductRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteProductMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteProductMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2744,7 +2528,7 @@ public final class ProductSearchGrpc {
         createReferenceImage(
             com.google.cloud.vision.v1p4beta1.CreateReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2762,7 +2546,7 @@ public final class ProductSearchGrpc {
         deleteReferenceImage(
             com.google.cloud.vision.v1p4beta1.DeleteReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2780,7 +2564,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ListReferenceImagesResponse>
         listReferenceImages(com.google.cloud.vision.v1p4beta1.ListReferenceImagesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListReferenceImagesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListReferenceImagesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2796,7 +2580,7 @@ public final class ProductSearchGrpc {
             com.google.cloud.vision.v1p4beta1.ReferenceImage>
         getReferenceImage(com.google.cloud.vision.v1p4beta1.GetReferenceImageRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetReferenceImageMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetReferenceImageMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2814,7 +2598,7 @@ public final class ProductSearchGrpc {
         addProductToProductSet(
             com.google.cloud.vision.v1p4beta1.AddProductToProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAddProductToProductSetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAddProductToProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2828,8 +2612,7 @@ public final class ProductSearchGrpc {
         removeProductFromProductSet(
             com.google.cloud.vision.v1p4beta1.RemoveProductFromProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRemoveProductFromProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getRemoveProductFromProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2848,8 +2631,7 @@ public final class ProductSearchGrpc {
         listProductsInProductSet(
             com.google.cloud.vision.v1p4beta1.ListProductsInProductSetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListProductsInProductSetMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListProductsInProductSetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2870,7 +2652,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importProductSets(com.google.cloud.vision.v1p4beta1.ImportProductSetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportProductSetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportProductSetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2901,7 +2683,7 @@ public final class ProductSearchGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         purgeProducts(com.google.cloud.vision.v1p4beta1.PurgeProductsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getPurgeProductsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getPurgeProductsMethod(), getCallOptions()), request);
     }
   }
 
@@ -3116,25 +2898,25 @@ public final class ProductSearchGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ProductSearchFileDescriptorSupplier())
-                      .addMethod(getCreateProductSetMethodHelper())
-                      .addMethod(getListProductSetsMethodHelper())
-                      .addMethod(getGetProductSetMethodHelper())
-                      .addMethod(getUpdateProductSetMethodHelper())
-                      .addMethod(getDeleteProductSetMethodHelper())
-                      .addMethod(getCreateProductMethodHelper())
-                      .addMethod(getListProductsMethodHelper())
-                      .addMethod(getGetProductMethodHelper())
-                      .addMethod(getUpdateProductMethodHelper())
-                      .addMethod(getDeleteProductMethodHelper())
-                      .addMethod(getCreateReferenceImageMethodHelper())
-                      .addMethod(getDeleteReferenceImageMethodHelper())
-                      .addMethod(getListReferenceImagesMethodHelper())
-                      .addMethod(getGetReferenceImageMethodHelper())
-                      .addMethod(getAddProductToProductSetMethodHelper())
-                      .addMethod(getRemoveProductFromProductSetMethodHelper())
-                      .addMethod(getListProductsInProductSetMethodHelper())
-                      .addMethod(getImportProductSetsMethodHelper())
-                      .addMethod(getPurgeProductsMethodHelper())
+                      .addMethod(getCreateProductSetMethod())
+                      .addMethod(getListProductSetsMethod())
+                      .addMethod(getGetProductSetMethod())
+                      .addMethod(getUpdateProductSetMethod())
+                      .addMethod(getDeleteProductSetMethod())
+                      .addMethod(getCreateProductMethod())
+                      .addMethod(getListProductsMethod())
+                      .addMethod(getGetProductMethod())
+                      .addMethod(getUpdateProductMethod())
+                      .addMethod(getDeleteProductMethod())
+                      .addMethod(getCreateReferenceImageMethod())
+                      .addMethod(getDeleteReferenceImageMethod())
+                      .addMethod(getListReferenceImagesMethod())
+                      .addMethod(getGetReferenceImageMethod())
+                      .addMethod(getAddProductToProductSetMethod())
+                      .addMethod(getRemoveProductFromProductSetMethod())
+                      .addMethod(getListProductsInProductSetMethod())
+                      .addMethod(getImportProductSetsMethod())
+                      .addMethod(getPurgeProductsMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,22 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'vision'
 versions = ['v1', 'v1p1beta1', 'v1p2beta1', 'v1p3beta1', 'v1p4beta1']
-config_pattern = '/google/cloud/vision/artman_vision_{version}.yaml'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)