### PR TITLE
build: fix blunderbuss team config

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -2,4 +2,4 @@ assign_prs_by:
 - labels:
   - samples
   to:
-  - java-samples-reviewers
+  - googleapis/java-samples-reviewers


### PR DESCRIPTION
Teams are identified by `<org>/<team-name>`
