### PR TITLE
test: adding native image configuration required for tests

### DIFF
--- a/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
+++ b/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
@@ -1,13 +1,13 @@
 {
   "resources":{
     "includes": [
-      {"pattern":"\\Qcity.jpg\\E"},
-      {"pattern":"\\Qface_no_surprise.jpg\\E"},
-      {"pattern":"\\Qlandmark.jpg\\E"},
-      {"pattern":"\\Qlogos.png\\E"},
-      {"pattern":"\\Qpuppies.jpg\\E"},
-      {"pattern":"\\Qtext.jpg\\E"},
-      {"pattern":"\\Qwakeupcat.jpg\\E"}
+      {"pattern":"\\Qsrc/test/resources/city.jpg\\E"},
+      {"pattern":"\\Qsrc/test/resources/face_no_surprise.jpg\\E"},
+      {"pattern":"\\Qsrc/test/resources/landmark.jpg\\E"},
+      {"pattern":"\\Qsrc/test/resources/logos.png\\E"},
+      {"pattern":"\\Qsrc/test/resources/puppies.jpg\\E"},
+      {"pattern":"\\Qsrc/test/resources/text.jpg\\E"},
+      {"pattern":"\\Qsrc/test/resources/wakeupcat.jpg\\E"}
     ]
   }
 }

--- a/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
+++ b/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
@@ -1,8 +1,13 @@
 {
   "resources":{
     "includes": [
-      {"pattern":".*.jpg"},
-      {"pattern":".*.png"}
+      {"pattern":"\\Qcity.jpg\\E"},
+      {"pattern":"\\Qface_no_surprise.jpg\\E"},
+      {"pattern":"\\Qlandmark.jpg\\E"},
+      {"pattern":"\\Qlogos.png\\E"},
+      {"pattern":"\\Qpuppies.jpg\\E"},
+      {"pattern":"\\Qtext.jpg\\E"},
+      {"pattern":"\\Qwakeupcat.jpg\\E"}
     ]
   }
 }

--- a/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
+++ b/google-cloud-vision/src/test/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources":{
+    "includes": [
+      {"pattern":".*.jpg"},
+      {"pattern":".*.png"}
+    ]
+  }
+}


### PR DESCRIPTION
Trying to fix "Kokoro - Test: Java GraalVM Native Image" build.

```
Failures (12):
  JUnit Vintage:ITSystemTest:detectLabelsTest
    MethodSource [className = 'com.google.cloud.vision.it.ITSystemTest', methodName = 'detectLabelsTest', methodParameterTypes = '']
    => java.io.FileNotFoundException: src/test/resources/wakeupcat.jpg (No such file or directory)
       com.oracle.svm.jni.JNIJavaCallWrappers.jniInvoke_VA_LIST:Ljava_io_FileNotFoundException_2_0002e_0003cinit_0003e_00028Ljava_lang_String_2Ljava_lang_String_2_00029V(JNIJavaCallWrappers.java:0)
       java.io.FileInputStream.open0(FileInputStream.java)
       java.io.FileInputStream.open(FileInputStream.java:219)
       java.io.FileInputStream.<init>(FileInputStream.java:157)
       java.io.FileInputStream.<init>(FileInputStream.java:112)
       com.google.cloud.vision.it.ITSystemTest.getResponsesList(ITSystemTest.java:223)
       com.google.cloud.vision.it.ITSystemTest.detectLabelsTest(ITSystemTest.java:263)
       java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
       org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
       [...]
...
```

https://source.cloud.google.com/results/invocations/cc541c2e-5da6-48bf-acb1-dd0d90f340b3/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-vision%2Fpresubmit%2Fgraalvm-native/log

The test execution requires some configuration for native image to load resource files.